### PR TITLE
Replace Middlesex County sources for 2016 general

### DIFF
--- a/2016/Middlesex/General/General Assembly 18th Legislative District Un Expi - Middlesex County.csv
+++ b/2016/Middlesex/General/General Assembly 18th Legislative District Un Expi - Middlesex County.csv
@@ -1,176 +1,176 @@
 District,Robert KARABINCHAK,Camille Ferraro CLARK
-"East Brunswick, District 1",2008,1593
-"East Brunswick, District 2",2225,1656
-"East Brunswick, District 3",1886,1530
-"East Brunswick, District 4",1933,1575
-"East Brunswick, District 5",1816,1425
-"East Brunswick, District 6",1802,1462
-"East Brunswick, District 7",1894,1538
-"East Brunswick, District 8",1892,1514
-"East Brunswick, District 9",1850,1522
-"East Brunswick, District 10",1881,1465
-"East Brunswick, District 11",1789,1442
-"East Brunswick, District 12",1857,1521
-"East Brunswick, District 13",1929,1506
-"East Brunswick, District 14",1995,1653
-"East Brunswick, District 15",1831,1434
-"East Brunswick, District 16",1911,1535
-"East Brunswick, District 17",1902,1511
-"East Brunswick, District 18",1846,1414
-"East Brunswick, District 19",1859,1451
-"East Brunswick, District 20",1988,1594
-"East Brunswick, District 21",1878,1526
-"East Brunswick, District 22",1871,1452
-"East Brunswick, District 23",1948,1567
-"East Brunswick, District 24",1861,1526
-"East Brunswick, District 25",1894,1483
-"East Brunswick, District 26",1942,1603
-"East Brunswick, District 27",1858,1585
-"East Brunswick, District 28",1810,1439
-"East Brunswick, District 29",1917,1507
-"East Brunswick, District 30",1956,1515
-"East Brunswick, District 31",1974,1573
-"East Brunswick, District 32",1858,1458
-"East Brunswick, District 33",1893,1451
-"East Brunswick, District 34",1989,1601
-"East Brunswick, District 35",1804,1456
-"East Brunswick, District 36",1912,1537
-"East Brunswick, District 37",1982,1519
-"East Brunswick, District 38",1888,1489
-"East Brunswick, District 39",1866,1504
-"East Brunswick, District 40",1940,1494
-"Edison, District 1",3021,1450
-"Edison, District 2",3271,1397
-"Edison, District 3",2954,1382
-"Edison, District 4",2860,1350
-"Edison, District 5",2940,1357
-"Edison, District 6",2975,1307
-"Edison, District 7",2834,1300
-"Edison, District 8",2878,1337
-"Edison, District 9",2837,1319
-"Edison, District 10",2892,1373
-"Edison, District 11",2956,1367
-"Edison, District 12",2998,1390
-"Edison, District 13",2930,1311
-"Edison, District 14",2966,1435
-"Edison, District 15",2953,1376
-"Edison, District 16",2968,1398
-"Edison, District 17",2928,1342
-"Edison, District 18",2857,1334
-"Edison, District 19",2917,1349
-"Edison, District 20",2884,1315
-"Edison, District 21",2909,1360
-"Edison, District 22",2877,1326
-"Edison, District 23",2939,1371
-"Edison, District 24",2899,1342
-"Edison, District 25",2887,1308
-"Edison, District 26",2892,1361
-"Edison, District 27",3052,1444
-"Edison, District 28",2854,1259
-"Edison, District 29",2975,1352
-"Edison, District 30",3038,1443
-"Edison, District 31",2952,1364
-"Edison, District 32",2906,1313
-"Edison, District 33",2898,1348
-"Edison, District 34",2842,1336
-"Edison, District 35",2906,1356
-"Edison, District 36",2922,1320
-"Edison, District 37",2949,1377
-"Edison, District 38",2958,1323
-"Edison, District 39",3081,1298
-"Edison, District 40",2921,1344
-"Edison, District 41",2889,1307
-"Edison, District 42",2908,1285
-"Edison, District 43",3174,1330
-"Edison, District 44",2936,1389
-"Edison, District 45",2898,1352
-"Edison, District 46",2884,1336
-"Edison, District 47",2888,1330
-"Edison, District 48",2836,1313
-"Edison, District 49",2949,1354
-"Edison, District 50",2923,1341
-"Edison, District 51",2872,1311
-"Edison, District 52",2886,1345
-"Edison, District 53",2946,1372
-"Edison, District 54",2900,1333
-"Edison, District 55",2844,1316
-"Edison, District 56",2874,1317
-"Edison, District 57",2919,1339
-"Edison, District 58",3014,1285
-"Edison, District 59",2873,1313
-"Edison, District 60",2871,1338
-"Edison, District 61",2998,1378
-"Edison, District 62",2884,1365
-"Edison, District 63",3100,1347
-"Edison, District 64",3037,1394
-"Edison, District 65",3004,1387
-"Edison, District 66",3008,1384
-"Edison, District 67",2951,1429
-"Edison, District 68",3010,1439
-"Edison, District 69",2912,1327
-"Edison, District 70",3105,1389
-"Edison, District 71",2979,1344
-"Edison, District 72",3161,1445
-"Edison, District 73",2997,1407
-"Edison, District 74",2930,1357
-"Edison, District 75",2976,1281
-"Edison, District 76",3054,1375
-"Edison, District 77",3128,1352
-"Edison, District 78",3008,1272
-"Helmetta, District 1",368,505
-"Highland Park, District 1",974,252
-"Highland Park, District 2",924,178
-"Highland Park, District 3",897,176
-"Highland Park, District 4",894,166
-"Highland Park, District 5",946,231
-"Highland Park, District 6",935,166
-"Highland Park, District 7",962,197
-"Highland Park, District 8",926,189
-"Highland Park, District 9",877,207
-"Highland Park, District 10",877,255
-"Highland Park, District 11",904,247
-"Highland Park, District 12",838,178
-"Highland Park, District 13",882,190
-"Metuchen, District 1",892,589
-"Metuchen, District 2",954,557
-"Metuchen, District 3",898,493
-"Metuchen, District 4",873,478
-"Metuchen, District 5",909,514
-"Metuchen, District 6",856,471
-"Metuchen, District 7",851,488
-"Metuchen, District 8",856,472
-"Metuchen, District 9",817,451
-"Metuchen, District 10",984,564
-"Metuchen, District 11",1109,592
-"Metuchen, District 12",856,500
-"Metuchen, District 13",803,446
-"South Plainfield, District 1",781,529
-"South Plainfield, District 2",726,611
-"South Plainfield, District 3",744,561
-"South Plainfield, District 4",908,720
-"South Plainfield, District 5",662,562
-"South Plainfield, District 6",746,589
-"South Plainfield, District 7",828,606
-"South Plainfield, District 8",773,610
-"South Plainfield, District 9",694,607
-"South Plainfield, District 10",998,623
-"South Plainfield, District 11",692,572
-"South Plainfield, District 12",679,590
-"South Plainfield, District 13",835,620
-"South Plainfield, District 14",734,654
-"South Plainfield, District 15",894,513
-"South River, District 1",416,327
-"South River, District 2",371,337
-"South River, District 3",374,363
-"South River, District 4",359,354
-"South River, District 5",388,387
-"South River, District 6",416,373
-"South River, District 7",397,348
-"South River, District 8",391,368
-"South River, District 9",407,319
-"South River, District 10",575,455
-"South River, District 11",447,376
-"South River, District 12",430,347
-"South River, District 13",384,353
-"South River, District 14",372,374
-Total,347420,189838
+"East Brunswick, District 1",2186,1703
+"East Brunswick, District 2",543,343
+"East Brunswick, District 3",204,217
+"East Brunswick, District 4",251,262
+"East Brunswick, District 5",134,112
+"East Brunswick, District 6",120,149
+"East Brunswick, District 7",212,225
+"East Brunswick, District 8",210,201
+"East Brunswick, District 9",168,209
+"East Brunswick, District 10",199,152
+"East Brunswick, District 11",107,129
+"East Brunswick, District 12",175,208
+"East Brunswick, District 13",247,193
+"East Brunswick, District 14",313,340
+"East Brunswick, District 15",149,121
+"East Brunswick, District 16",229,222
+"East Brunswick, District 17",220,198
+"East Brunswick, District 18",164,101
+"East Brunswick, District 19",177,138
+"East Brunswick, District 20",306,281
+"East Brunswick, District 21",196,213
+"East Brunswick, District 22",189,139
+"East Brunswick, District 23",266,254
+"East Brunswick, District 24",179,213
+"East Brunswick, District 25",212,170
+"East Brunswick, District 26",260,290
+"East Brunswick, District 27",176,272
+"East Brunswick, District 28",128,126
+"East Brunswick, District 29",235,194
+"East Brunswick, District 30",274,202
+"East Brunswick, District 31",292,260
+"East Brunswick, District 32",176,145
+"East Brunswick, District 33",211,138
+"East Brunswick, District 34",307,288
+"East Brunswick, District 35",122,143
+"East Brunswick, District 36",230,224
+"East Brunswick, District 37",300,206
+"East Brunswick, District 38",206,176
+"East Brunswick, District 39",184,191
+"East Brunswick, District 40",258,181
+"Edison, District 1",3393,1627
+"Edison, District 2",554,175
+"Edison, District 3",237,160
+"Edison, District 4",143,128
+"Edison, District 5",223,135
+"Edison, District 6",258,85
+"Edison, District 7",117,78
+"Edison, District 8",161,115
+"Edison, District 9",120,97
+"Edison, District 10",175,151
+"Edison, District 11",239,145
+"Edison, District 12",281,168
+"Edison, District 13",213,89
+"Edison, District 14",249,213
+"Edison, District 15",236,154
+"Edison, District 16",251,176
+"Edison, District 17",211,120
+"Edison, District 18",140,112
+"Edison, District 19",200,127
+"Edison, District 20",167,93
+"Edison, District 21",192,138
+"Edison, District 22",160,104
+"Edison, District 23",222,149
+"Edison, District 24",182,120
+"Edison, District 25",170,86
+"Edison, District 26",175,139
+"Edison, District 27",335,222
+"Edison, District 28",137,37
+"Edison, District 29",258,130
+"Edison, District 30",321,221
+"Edison, District 31",235,142
+"Edison, District 32",189,91
+"Edison, District 33",181,126
+"Edison, District 34",125,114
+"Edison, District 35",189,134
+"Edison, District 36",205,98
+"Edison, District 37",232,155
+"Edison, District 38",241,101
+"Edison, District 39",364,76
+"Edison, District 40",204,122
+"Edison, District 41",172,85
+"Edison, District 42",191,63
+"Edison, District 43",457,108
+"Edison, District 44",219,167
+"Edison, District 45",181,130
+"Edison, District 46",167,114
+"Edison, District 47",171,108
+"Edison, District 48",119,91
+"Edison, District 49",232,132
+"Edison, District 50",206,119
+"Edison, District 51",155,89
+"Edison, District 52",169,123
+"Edison, District 53",229,150
+"Edison, District 54",183,111
+"Edison, District 55",127,94
+"Edison, District 56",157,95
+"Edison, District 57",202,117
+"Edison, District 58",297,63
+"Edison, District 59",156,91
+"Edison, District 60",154,116
+"Edison, District 61",281,156
+"Edison, District 62",167,143
+"Edison, District 63",383,125
+"Edison, District 64",320,172
+"Edison, District 65",287,165
+"Edison, District 66",291,162
+"Edison, District 67",234,207
+"Edison, District 68",293,217
+"Edison, District 69",195,105
+"Edison, District 70",388,167
+"Edison, District 71",262,122
+"Edison, District 72",444,223
+"Edison, District 73",280,185
+"Edison, District 74",213,135
+"Edison, District 75",259,59
+"Edison, District 76",337,153
+"Edison, District 77",411,130
+"Edison, District 78",291,50
+"Helmetta, District 1",372,513
+"Highland Park, District 1",1042,273
+"Highland Park, District 2",298,63
+"Highland Park, District 3",271,61
+"Highland Park, District 4",268,51
+"Highland Park, District 5",320,116
+"Highland Park, District 6",309,51
+"Highland Park, District 7",336,82
+"Highland Park, District 8",300,74
+"Highland Park, District 9",251,92
+"Highland Park, District 10",251,140
+"Highland Park, District 11",278,132
+"Highland Park, District 12",212,63
+"Highland Park, District 13",256,75
+"Metuchen, District 1",942,619
+"Metuchen, District 2",329,217
+"Metuchen, District 3",273,153
+"Metuchen, District 4",248,138
+"Metuchen, District 5",284,174
+"Metuchen, District 6",231,131
+"Metuchen, District 7",226,148
+"Metuchen, District 8",231,132
+"Metuchen, District 9",192,111
+"Metuchen, District 10",359,224
+"Metuchen, District 11",484,252
+"Metuchen, District 12",231,160
+"Metuchen, District 13",178,106
+"South Plainfield, District 1",844,563
+"South Plainfield, District 2",258,263
+"South Plainfield, District 3",276,213
+"South Plainfield, District 4",440,372
+"South Plainfield, District 5",194,214
+"South Plainfield, District 6",278,241
+"South Plainfield, District 7",360,258
+"South Plainfield, District 8",305,262
+"South Plainfield, District 9",226,259
+"South Plainfield, District 10",530,275
+"South Plainfield, District 11",224,224
+"South Plainfield, District 12",211,242
+"South Plainfield, District 13",367,272
+"South Plainfield, District 14",266,306
+"South Plainfield, District 15",426,165
+"South River, District 1",447,351
+"South River, District 2",117,123
+"South River, District 3",120,149
+"South River, District 4",105,140
+"South River, District 5",134,173
+"South River, District 6",162,159
+"South River, District 7",143,134
+"South River, District 8",137,154
+"South River, District 9",153,105
+"South River, District 10",321,241
+"South River, District 11",193,162
+"South River, District 12",176,133
+"South River, District 13",130,139
+"South River, District 14",118,160
+Total,48513,31827

--- a/2016/Middlesex/General/House Of Representatives 12th Congressional District - Middlesex County.csv
+++ b/2016/Middlesex/General/House Of Representatives 12th Congressional District - Middlesex County.csv
@@ -1,239 +1,244 @@
 District,Bonnie Watson COLEMAN,Steven J. UCCIO,R. Edward FORCHION,Robert SHAPIRO,Thomas FITZPATRICK,Steven WELZER,Michael R. BOLLENTIN
-"Cranbury, District 1",480,347,14,3,9,10,5
-"Cranbury, District 2",479,442,15,10,8,7,3
-"Cranbury, District 3",437,341,14,4,5,7,8
-"Dunellen, District 1",288,211,15,6,8,4,3
-"Dunellen, District 2",415,263,17,9,6,7,5
-"Dunellen, District 3",225,254,7,6,10,3,5
-"Dunellen, District 4",279,196,14,9,7,4,4
-"Dunellen, District 5",319,295,9,6,8,6,3
-"Dunellen, District 6",236,208,14,8,7,2,3
-"East Brunswick, District 1",2127,1407,76,34,31,21,17
-"East Brunswick, District 2",2359,1465,82,31,30,25,19
-"East Brunswick, District 3",2002,1347,75,30,30,23,18
-"East Brunswick, District 4",2059,1396,71,26,27,21,18
-"East Brunswick, District 5",1924,1253,65,32,26,24,18
-"East Brunswick, District 6",1915,1287,74,27,26,20,18
-"East Brunswick, District 7",2021,1355,66,32,28,22,16
-"East Brunswick, District 8",1998,1335,77,32,28,22,19
-"East Brunswick, District 9",1973,1340,76,28,29,19,17
-"East Brunswick, District 10",1995,1291,72,28,27,21,18
-"East Brunswick, District 11",1896,1275,73,28,26,20,16
-"East Brunswick, District 12",1986,1338,66,27,32,19,17
-"East Brunswick, District 13",2042,1327,79,26,31,23,16
-"East Brunswick, District 14",2134,1462,66,31,29,22,17
-"East Brunswick, District 15",1944,1260,67,28,30,21,17
-"East Brunswick, District 16",2040,1358,70,31,28,20,16
-"East Brunswick, District 17",2030,1342,64,27,26,19,16
-"East Brunswick, District 18",1950,1245,69,29,28,19,18
-"East Brunswick, District 19",1968,1273,70,27,31,21,20
-"East Brunswick, District 20",2116,1411,76,29,28,23,17
-"East Brunswick, District 21",2001,1343,70,30,28,20,19
-"East Brunswick, District 22",1998,1273,73,30,28,20,16
-"East Brunswick, District 23",2079,1379,74,30,30,21,16
-"East Brunswick, District 24",1985,1344,69,28,31,22,19
-"East Brunswick, District 25",2006,1309,70,30,26,23,17
-"East Brunswick, District 26",2055,1414,72,30,28,24,17
-"East Brunswick, District 27",1965,1414,70,35,30,20,17
-"East Brunswick, District 28",1919,1274,70,26,28,19,16
-"East Brunswick, District 29",2034,1336,67,34,29,21,18
-"East Brunswick, District 30",2071,1347,66,27,27,21,18
-"East Brunswick, District 31",2101,1392,78,26,29,23,17
-"East Brunswick, District 32",1973,1287,70,29,27,22,17
-"East Brunswick, District 33",2005,1273,75,30,29,23,20
-"East Brunswick, District 34",2119,1403,72,31,27,22,17
-"East Brunswick, District 35",1921,1281,68,28,26,23,16
-"East Brunswick, District 36",2042,1340,74,30,26,20,16
-"East Brunswick, District 37",2088,1344,69,33,27,23,19
-"East Brunswick, District 38",1991,1316,72,29,28,27,16
-"East Brunswick, District 39",1982,1327,72,28,28,20,21
-"East Brunswick, District 40",2059,1326,71,28,29,20,16
-"Helmetta, District 1",358,472,35,14,9,4,6
-"Jamesburg, District 1",300,320,16,8,8,8,3
-"Jamesburg, District 2",219,204,13,8,10,5,1
-"Jamesburg, District 3",241,214,12,8,10,8,2
-"Jamesburg, District 4",313,332,20,10,10,4,2
-"Middlesex, District 1",416,368,27,13,5,7,10
-"Middlesex, District 2",509,516,32,10,6,11,9
-"Middlesex, District 3",475,401,20,7,6,10,8
-"Middlesex, District 4",475,534,22,11,7,6,8
-"Middlesex, District 5",441,547,28,9,6,6,11
-"Middlesex, District 6",349,408,23,9,5,7,7
-"Middlesex, District 7",471,520,33,9,9,9,10
-"Middlesex, District 8",462,497,21,9,11,7,9
-"Middlesex, District 9",482,507,22,11,5,9,8
-"Middlesex, District 10",564,453,30,12,17,8,10
-"Milltown, District 1",323,338,16,6,9,6,2
-"Milltown, District 2",374,436,15,9,12,5,4
-"Milltown, District 3",348,307,19,7,7,3,4
-"Milltown, District 4",301,307,19,6,9,5,6
-"Milltown, District 5",373,354,12,9,10,3,3
-"Milltown, District 6",294,275,14,8,9,2,3
-"Milltown, District 7",366,434,16,11,10,4,5
-"Milltown, District 8",355,379,15,12,12,4,3
-"Milltown, District 9",298,321,10,4,10,3,3
-"Monroe, Ward 1, District 1",1489,1061,27,15,19,8,13
-"Monroe, Ward 1, District 2",1414,1096,28,14,19,9,15
-"Monroe, Ward 1, District 3",1395,1066,26,14,17,9,13
-"Monroe, Ward 1, District 4",1431,1086,28,17,17,10,15
-"Monroe, Ward 1, District 5",1418,1072,28,17,17,9,15
-"Monroe, Ward 1, District 6",1368,1008,29,14,17,8,13
-"Monroe, Ward 1, District 7",1418,1059,26,16,18,8,14
-"Monroe, Ward 1, District 8",1373,996,25,16,17,8,14
-"Monroe, Ward 1, District 9",1437,1034,26,18,20,8,14
-"Monroe, Ward 1, District 10",1449,1054,28,14,17,9,14
-"Monroe, Ward 1, District 11",1335,1085,27,15,22,10,15
-"Monroe, Ward 1, District 12",1526,1123,34,21,22,11,15
-"Monroe, Ward 1, District 13",1578,1134,28,16,19,9,13
-"Monroe, Ward 1, District 14",1755,1163,28,26,21,13,21
-"Monroe, Ward 1, District 15",1443,1052,31,15,19,12,15
-"Monroe, Ward 1, District 16",1413,1087,27,14,17,8,14
-"Monroe, Ward 1, District 17",1535,1088,40,18,20,10,15
-"Monroe, Ward 2, District 1",2417,1920,58,33,25,15,34
-"Monroe, Ward 2, District 2",2320,1682,65,32,24,18,23
-"Monroe, Ward 2, District 3",2329,1534,45,27,25,16,21
-"Monroe, Ward 2, District 4",2281,1750,62,33,26,15,23
-"Monroe, Ward 2, District 5",2262,1515,43,26,24,15,20
-"Monroe, Ward 2, District 6",2291,1525,46,30,23,15,20
-"Monroe, Ward 2, District 7",2344,1524,44,27,25,18,20
-"Monroe, Ward 2, District 8",2247,1488,42,28,24,14,20
-"Monroe, Ward 2, District 9",2333,1550,44,28,26,14,21
-"Monroe, Ward 2, District 10",2271,1603,48,27,23,15,23
-"Monroe, Ward 2, District 11",2250,1519,45,29,22,14,21
-"Monroe, Ward 2, District 12",2303,1507,45,29,24,14,20
-"Monroe, Ward 3, District 1",1389,1145,42,16,20,10,18
-"Monroe, Ward 3, District 2",1387,1075,35,20,22,8,15
-"Monroe, Ward 3, District 3",1393,1108,33,28,21,9,13
-"Monroe, Ward 3, District 4",1413,1190,41,21,18,9,14
-"Monroe, Ward 3, District 5",1494,1232,42,21,20,10,15
-"Monroe, Ward 3, District 6",1378,1142,28,15,21,8,16
-"Monroe, Ward 3, District 7",1431,1231,31,20,19,12,19
-"Monroe, Ward 3, District 8",1424,1196,39,13,22,11,15
-"Monroe, Ward 3, District 9",1476,1326,40,19,22,10,17
-"Monroe, Ward 3, District 10",1608,1236,26,15,19,9,13
-"Monroe, Ward 3, District 11",1440,1088,28,18,18,9,13
-"North Brunswick, District 1",1243,588,51,21,15,19,10
-"North Brunswick, District 2",1329,646,53,22,17,13,8
-"North Brunswick, District 3",1243,561,55,21,14,16,10
-"North Brunswick, District 4",1430,598,49,20,17,16,10
-"North Brunswick, District 5",1336,660,65,21,17,20,9
-"North Brunswick, District 6",1267,553,57,24,17,15,12
-"North Brunswick, District 7",1258,677,47,21,17,15,9
-"North Brunswick, District 8",1176,550,46,22,15,16,13
-"North Brunswick, District 9",1310,646,54,23,19,14,10
-"North Brunswick, District 10",1169,566,43,21,16,13,11
-"North Brunswick, District 11",1406,799,57,20,18,15,9
-"North Brunswick, District 12",1236,537,53,18,17,15,9
-"North Brunswick, District 13",1219,609,43,19,16,14,10
-"North Brunswick, District 14",1160,529,43,19,18,13,10
-"North Brunswick, District 15",1203,494,43,19,15,15,9
-"North Brunswick, District 16",1255,555,49,18,19,19,11
-"North Brunswick, District 17",1317,580,48,19,15,19,9
-"North Brunswick, District 18",1201,595,45,17,14,15,10
-"North Brunswick, District 19",1488,616,54,25,15,17,11
-"North Brunswick, District 20",1530,638,59,28,16,14,11
-"North Brunswick, District 21",1696,607,67,25,15,19,11
-"North Brunswick, District 22",1330,576,50,21,15,17,8
-"North Brunswick, District 23",1313,588,52,19,15,16,9
-"North Brunswick, District 24",1297,543,50,22,21,15,10
-"North Brunswick, District 25",1622,711,64,28,22,19,12
-"North Brunswick, District 26",1301,550,50,20,16,19,10
-"North Brunswick, District 27",1672,582,57,25,16,19,10
-"Old Bridge, Ward 1, District 10",746,686,37,15,12,10,8
-"Old Bridge, Ward 2, District 6",695,641,36,14,12,10,5
-"Old Bridge, Ward 2, District 7",866,767,37,15,14,12,6
-"Old Bridge, Ward 3, District 1",1047,905,60,21,21,16,7
-"Old Bridge, Ward 3, District 2",1079,966,59,16,20,16,5
-"Old Bridge, Ward 3, District 3",1236,766,58,20,19,20,6
-"Old Bridge, Ward 3, District 4",1166,794,62,21,18,16,9
-"Old Bridge, Ward 3, District 5",1093,883,61,17,18,16,7
-"Old Bridge, Ward 3, District 6",970,912,53,21,19,15,7
-"Old Bridge, Ward 3, District 7",939,839,44,17,18,16,8
-"Old Bridge, Ward 4, District 1",911,822,45,18,18,13,5
-"Old Bridge, Ward 4, District 2",858,727,49,15,18,11,7
-"Old Bridge, Ward 4, District 4",787,730,41,17,15,12,7
-"Old Bridge, Ward 4, District 5",829,794,51,20,19,11,6
-"Old Bridge, Ward 4, District 7",809,791,39,15,17,13,5
-"Old Bridge, Ward 4, District 8",898,756,43,16,14,11,9
-"Old Bridge, Ward 4, District 9",735,684,39,14,13,10,7
-"Old Bridge, Ward 5, District 1",804,803,40,17,14,11,6
-"Old Bridge, Ward 5, District 2",784,838,47,16,21,10,5
-"Old Bridge, Ward 5, District 3",797,769,43,16,16,11,8
-"Old Bridge, Ward 5, District 4",800,802,48,16,15,15,6
-"Old Bridge, Ward 5, District 5",815,813,49,21,15,11,7
-"Old Bridge, Ward 5, District 6",858,904,52,18,19,11,6
-"Old Bridge, Ward 5, District 7",911,877,48,18,16,12,6
-"Old Bridge, Ward 5, District 8",903,849,48,26,14,11,6
-"Old Bridge, Ward 5, District 9",819,811,44,16,14,11,6
-"Old Bridge, Ward 6, District 1",875,848,59,28,21,15,8
-"Old Bridge, Ward 6, District 2",844,866,49,21,15,10,10
-"Old Bridge, Ward 6, District 3",750,739,37,15,15,10,7
-"Old Bridge, Ward 6, District 4",803,816,47,17,16,12,6
-"Old Bridge, Ward 6, District 5",880,846,46,21,15,15,9
-"Old Bridge, Ward 6, District 6",899,850,51,27,14,12,8
-"Old Bridge, Ward 6, District 7",865,873,50,16,14,14,7
-"Old Bridge, Ward 6, District 8",999,914,43,17,18,14,5
-"Plainsboro, District 1",1236,452,40,13,12,18,9
-"Plainsboro, District 2",1027,295,38,15,11,14,9
-"Plainsboro, District 3",1116,380,35,15,10,13,9
-"Plainsboro, District 4",1149,374,36,15,10,17,8
-"Plainsboro, District 5",1383,445,36,20,10,21,8
-"Plainsboro, District 6",1079,345,25,15,7,11,5
-"Plainsboro, District 7",1035,303,23,12,6,11,7
-"Plainsboro, District 8",974,275,23,16,9,12,5
-"Plainsboro, District 9",1103,355,42,16,9,17,12
-"Plainsboro, District 10",1073,377,28,14,8,12,7
-"Plainsboro, District 11",913,259,27,15,8,12,5
-"Plainsboro, District 12",1013,298,34,14,5,12,7
-"South Brunswick, District 1",2060,995,64,23,26,12,14
-"South Brunswick, District 2",1946,903,62,24,16,11,13
-"South Brunswick, District 3",1932,874,64,22,20,14,14
-"South Brunswick, District 4",1859,1007,63,24,18,11,14
-"South Brunswick, District 5",1905,900,65,23,17,18,12
-"South Brunswick, District 6",1824,908,62,21,16,9,17
-"South Brunswick, District 7",1876,878,58,21,18,9,17
-"South Brunswick, District 8",1887,915,59,24,18,14,12
-"South Brunswick, District 9",1858,876,66,27,16,10,18
-"South Brunswick, District 10",1801,871,61,23,18,13,14
-"South Brunswick, District 11",1894,882,61,23,16,12,13
-"South Brunswick, District 12",1813,849,63,23,17,12,17
-"South Brunswick, District 13",1984,852,67,20,15,14,12
-"South Brunswick, District 14",1918,831,64,23,17,10,13
-"South Brunswick, District 15",2061,933,75,23,20,15,13
-"South Brunswick, District 16",2170,942,60,28,14,10,13
-"South Brunswick, District 17",1984,824,68,23,19,19,16
-"South Brunswick, District 18",1984,862,61,24,17,10,14
-"South Brunswick, District 19",1924,815,65,23,18,12,12
-"South Brunswick, District 20",1862,842,63,23,15,17,13
-"South Brunswick, District 21",1922,912,57,21,19,11,12
-"South Brunswick, District 22",2007,893,70,23,18,10,12
-"South Brunswick, District 23",1982,821,64,23,17,10,14
-"South Brunswick, District 24",1853,883,63,28,19,12,13
-"South Brunswick, District 25",1983,844,59,20,18,13,15
-"South Brunswick, District 26",2080,987,66,30,17,11,16
-"South Brunswick, District 27",2006,900,56,23,17,9,15
-"South Brunswick, District 28",2100,913,59,24,18,11,18
-"South Brunswick, District 29",1985,856,61,25,17,13,13
-"South Brunswick, District 30",1946,830,69,23,14,10,14
-"South River, District 1",422,297,19,7,3,3,6
-"South River, District 2",389,297,22,7,2,4,7
-"South River, District 3",371,335,22,9,5,3,6
-"South River, District 4",367,323,16,10,2,4,6
-"South River, District 5",400,344,18,9,2,5,10
-"South River, District 6",420,335,19,8,3,4,8
-"South River, District 7",406,314,21,7,1,5,7
-"South River, District 8",379,339,25,9,4,3,8
-"South River, District 9",408,289,22,9,1,4,7
-"South River, District 10",580,426,20,9,4,6,6
-"South River, District 11",452,340,23,11,3,6,7
-"South River, District 12",434,311,29,12,5,5,8
-"South River, District 13",389,314,25,9,7,4,7
-"South River, District 14",381,331,23,12,4,6,9
-"Spotswood, District 1",428,520,48,16,20,2,7
-"Spotswood, District 2",284,379,27,11,18,4,3
-"Spotswood, District 3",278,320,27,8,14,3,4
-"Spotswood, District 4",302,326,27,10,13,4,8
-"Spotswood, District 5",348,400,38,20,14,6,10
-"Spotswood, District 6",292,315,27,9,11,6,5
-"Spotswood, District 7",264,398,27,9,14,5,5
-Total,306974,197684,10749,4583,4027,2994,2713
+"Cranbury, District 1",503,361,14,3,10,11,6
+"Cranbury, District 2",285,317,8,8,5,1,2
+"Cranbury, District 3",243,216,7,2,2,1,7
+"Dunellen, District 1",304,218,15,6,9,5,3
+"Dunellen, District 2",318,185,15,6,4,6,3
+"Dunellen, District 3",128,176,5,3,8,2,3
+"Dunellen, District 4",182,118,12,6,5,3,2
+"Dunellen, District 5",222,217,7,3,6,5,1
+"Dunellen, District 6",139,130,12,5,5,1,1
+"East Brunswick, District 1",2348,1522,84,41,33,24,19
+"East Brunswick, District 2",569,312,19,6,4,6,3
+"East Brunswick, District 3",212,194,12,5,4,4,2
+"East Brunswick, District 4",269,243,8,1,1,2,2
+"East Brunswick, District 5",134,100,2,7,0,5,2
+"East Brunswick, District 6",125,134,11,2,0,1,2
+"East Brunswick, District 7",231,202,3,7,2,3,0
+"East Brunswick, District 8",208,182,14,7,2,3,3
+"East Brunswick, District 9",183,187,13,3,3,0,1
+"East Brunswick, District 10",205,138,9,3,1,2,2
+"East Brunswick, District 11",106,122,10,3,0,1,0
+"East Brunswick, District 12",196,185,3,2,6,0,1
+"East Brunswick, District 13",252,174,16,1,5,4,0
+"East Brunswick, District 14",344,309,3,6,3,3,1
+"East Brunswick, District 15",154,107,4,3,4,2,1
+"East Brunswick, District 16",250,205,7,6,2,1,0
+"East Brunswick, District 17",240,189,1,2,0,0,0
+"East Brunswick, District 18",160,92,6,4,2,0,2
+"East Brunswick, District 19",178,120,7,2,5,2,4
+"East Brunswick, District 20",326,258,13,4,2,4,1
+"East Brunswick, District 21",211,190,7,5,2,1,3
+"East Brunswick, District 22",208,120,10,5,2,1,0
+"East Brunswick, District 23",289,226,11,5,4,2,0
+"East Brunswick, District 24",195,191,6,3,5,3,3
+"East Brunswick, District 25",216,156,7,5,0,4,1
+"East Brunswick, District 26",265,261,9,5,2,5,1
+"East Brunswick, District 27",175,261,7,10,4,1,1
+"East Brunswick, District 28",129,121,7,1,2,0,0
+"East Brunswick, District 29",244,183,4,9,3,2,2
+"East Brunswick, District 30",281,194,3,2,1,2,2
+"East Brunswick, District 31",311,239,15,1,3,4,1
+"East Brunswick, District 32",183,134,7,4,1,3,1
+"East Brunswick, District 33",215,120,12,5,3,4,4
+"East Brunswick, District 34",329,250,9,6,1,3,1
+"East Brunswick, District 35",131,128,5,3,0,4,0
+"East Brunswick, District 36",252,187,11,5,0,1,0
+"East Brunswick, District 37",298,191,6,8,1,4,3
+"East Brunswick, District 38",201,163,9,4,2,8,0
+"East Brunswick, District 39",192,174,9,3,2,1,5
+"East Brunswick, District 40",269,173,8,3,3,1,0
+"Helmetta, District 1",364,480,35,14,10,4,6
+"Jamesburg, District 1",311,326,17,8,8,9,3
+"Jamesburg, District 2",140,119,12,7,2,1,1
+"Jamesburg, District 3",162,129,11,7,2,4,2
+"Jamesburg, District 4",234,247,19,9,2,0,2
+"Middlesex, District 1",456,388,28,14,5,7,12
+"Middlesex, District 2",270,288,19,5,3,5,2
+"Middlesex, District 3",236,173,7,2,3,4,1
+"Middlesex, District 4",236,306,9,6,4,0,1
+"Middlesex, District 5",202,319,15,4,3,0,4
+"Middlesex, District 6",110,180,10,4,2,1,0
+"Middlesex, District 7",232,292,20,4,6,3,3
+"Middlesex, District 8",223,269,8,4,8,1,2
+"Middlesex, District 9",243,279,9,6,2,3,1
+"Middlesex, District 10",325,225,17,7,14,2,3
+"Milltown, District 1",347,354,17,7,11,6,2
+"Milltown, District 2",186,266,10,5,5,3,2
+"Milltown, District 3",160,137,14,3,0,1,2
+"Milltown, District 4",113,137,14,2,2,3,4
+"Milltown, District 5",185,184,7,5,3,1,1
+"Milltown, District 6",106,105,9,4,2,0,1
+"Milltown, District 7",178,264,11,7,3,2,3
+"Milltown, District 8",167,209,10,8,5,2,1
+"Milltown, District 9",110,151,5,0,3,1,1
+"Monroe, Ward 1, District 1",1603,1178,32,17,20,8,15
+"Monroe, Ward 1, District 2",176,186,3,1,2,1,2
+"Monroe, Ward 1, District 3",157,156,1,1,0,1,0
+"Monroe, Ward 1, District 4",193,176,3,4,0,2,2
+"Monroe, Ward 1, District 5",180,162,3,4,0,1,2
+"Monroe, Ward 1, District 6",130,98,4,1,0,0,0
+"Monroe, Ward 1, District 7",180,149,1,3,1,0,1
+"Monroe, Ward 1, District 8",135,86,0,3,0,0,1
+"Monroe, Ward 1, District 9",199,124,1,5,3,0,1
+"Monroe, Ward 1, District 10",211,144,3,1,0,1,1
+"Monroe, Ward 1, District 11",97,175,2,2,5,2,2
+"Monroe, Ward 1, District 12",288,213,9,8,5,3,2
+"Monroe, Ward 1, District 13",340,224,3,3,2,1,0
+"Monroe, Ward 1, District 14",517,253,3,13,4,5,8
+"Monroe, Ward 1, District 15",205,142,6,2,2,4,2
+"Monroe, Ward 1, District 16",175,177,2,1,0,0,1
+"Monroe, Ward 1, District 17",297,178,15,5,3,2,2
+"Monroe, Ward 2, District 1",1260,1066,35,20,8,8,21
+"Monroe, Ward 2, District 2",252,292,23,7,2,4,3
+"Monroe, Ward 2, District 3",261,144,3,2,3,2,1
+"Monroe, Ward 2, District 4",213,360,20,8,4,1,3
+"Monroe, Ward 2, District 5",194,125,1,1,2,1,0
+"Monroe, Ward 2, District 6",223,135,4,5,1,1,0
+"Monroe, Ward 2, District 7",276,134,2,2,3,4,0
+"Monroe, Ward 2, District 8",179,98,0,3,2,0,0
+"Monroe, Ward 2, District 9",265,160,2,3,4,0,1
+"Monroe, Ward 2, District 10",203,213,6,2,1,1,3
+"Monroe, Ward 2, District 11",182,129,3,4,0,0,1
+"Monroe, Ward 2, District 12",235,117,3,4,2,0,0
+"Monroe, Ward 2, District 13",272,307,10,6,6,2,2
+"Monroe, Ward 2, District 14",281,229,2,2,0,1,1
+"Monroe, Ward 2, District 15",221,208,3,4,0,0,0
+"Monroe, Ward 3, District 1",151,235,17,3,3,2,5
+"Monroe, Ward 3, District 2",149,165,10,7,5,0,2
+"Monroe, Ward 3, District 3",155,198,8,15,4,1,0
+"Monroe, Ward 3, District 4",175,280,16,8,1,1,1
+"Monroe, Ward 3, District 5",256,322,17,8,3,2,2
+"Monroe, Ward 3, District 6",140,232,3,2,4,0,3
+"Monroe, Ward 3, District 7",193,321,6,7,2,4,6
+"Monroe, Ward 3, District 8",186,286,14,0,5,3,2
+"Monroe, Ward 3, District 9",238,416,15,6,5,2,4
+"Monroe, Ward 3, District 10",370,326,1,2,2,1,0
+"Monroe, Ward 3, District 11",202,178,3,5,1,1,0
+"North Brunswick, District 1",1406,641,62,24,18,22,12
+"North Brunswick, District 2",309,183,14,6,3,0,0
+"North Brunswick, District 3",223,98,16,5,0,3,2
+"North Brunswick, District 4",410,135,10,4,3,3,2
+"North Brunswick, District 5",316,197,26,5,3,7,1
+"North Brunswick, District 6",247,90,18,8,3,2,4
+"North Brunswick, District 7",238,214,8,5,3,2,1
+"North Brunswick, District 8",156,87,7,6,1,3,5
+"North Brunswick, District 9",290,183,15,7,5,1,2
+"North Brunswick, District 10",149,103,4,5,2,0,3
+"North Brunswick, District 11",386,336,18,4,4,2,1
+"North Brunswick, District 12",216,74,14,2,3,2,1
+"North Brunswick, District 13",199,146,4,3,2,1,2
+"North Brunswick, District 14",140,66,4,3,4,0,2
+"North Brunswick, District 15",183,31,4,3,1,2,1
+"North Brunswick, District 16",235,92,10,2,5,6,3
+"North Brunswick, District 17",297,117,9,3,1,6,1
+"North Brunswick, District 18",181,132,6,1,0,2,2
+"North Brunswick, District 19",468,153,15,9,1,4,3
+"North Brunswick, District 20",510,175,20,12,2,1,3
+"North Brunswick, District 21",676,144,28,9,1,6,3
+"North Brunswick, District 22",310,113,11,5,1,4,0
+"North Brunswick, District 23",293,125,13,3,1,3,1
+"North Brunswick, District 24",277,80,11,6,7,2,2
+"North Brunswick, District 25",602,248,25,12,8,6,4
+"North Brunswick, District 26",281,87,11,4,2,6,2
+"North Brunswick, District 27",652,119,18,9,2,6,2
+"Old Bridge, Ward 1, District 10",837,775,46,18,14,12,10
+"Old Bridge, Ward 2, District 6",24,36,3,2,0,0,0
+"Old Bridge, Ward 2, District 7",195,162,4,3,2,2,1
+"Old Bridge, Ward 3, District 1",431,320,29,9,10,7,3
+"Old Bridge, Ward 3, District 2",254,257,19,2,5,3,0
+"Old Bridge, Ward 3, District 3",411,57,18,6,4,7,1
+"Old Bridge, Ward 3, District 4",341,85,22,7,3,3,4
+"Old Bridge, Ward 3, District 5",268,174,21,3,3,3,2
+"Old Bridge, Ward 3, District 6",145,203,13,7,4,2,2
+"Old Bridge, Ward 3, District 7",114,130,4,3,3,3,3
+"Old Bridge, Ward 4, District 1",240,217,12,6,6,3,0
+"Old Bridge, Ward 4, District 2",187,122,16,3,6,1,2
+"Old Bridge, Ward 4, District 4",116,125,8,5,3,2,2
+"Old Bridge, Ward 4, District 5",158,189,18,8,7,1,1
+"Old Bridge, Ward 4, District 7",138,186,6,3,5,3,0
+"Old Bridge, Ward 4, District 8",227,151,10,4,2,1,4
+"Old Bridge, Ward 4, District 9",64,79,6,2,1,0,2
+"Old Bridge, Ward 5, District 1",133,198,7,5,2,1,1
+"Old Bridge, Ward 5, District 2",113,233,14,4,9,0,0
+"Old Bridge, Ward 5, District 3",126,164,10,4,4,1,3
+"Old Bridge, Ward 5, District 4",129,197,15,4,3,5,1
+"Old Bridge, Ward 5, District 5",144,208,16,9,3,1,2
+"Old Bridge, Ward 5, District 6",187,299,19,6,7,1,1
+"Old Bridge, Ward 5, District 7",240,272,15,6,4,2,1
+"Old Bridge, Ward 5, District 8",232,244,15,14,2,1,1
+"Old Bridge, Ward 5, District 9",148,206,11,4,2,1,1
+"Old Bridge, Ward 5, District 10",251,247,11,8,3,4,3
+"Old Bridge, Ward 6, District 1",204,243,26,16,9,5,3
+"Old Bridge, Ward 6, District 2",173,261,16,9,3,0,5
+"Old Bridge, Ward 6, District 3",79,134,4,3,3,0,2
+"Old Bridge, Ward 6, District 4",132,211,14,5,4,2,1
+"Old Bridge, Ward 6, District 5",209,241,13,9,3,5,4
+"Old Bridge, Ward 6, District 6",228,245,18,15,2,2,3
+"Old Bridge, Ward 6, District 7",194,268,17,4,2,4,2
+"Old Bridge, Ward 6, District 8",328,309,10,5,6,4,0
+"Plainsboro, District 1",1398,490,44,16,13,23,9
+"Plainsboro, District 2",261,79,16,4,6,4,4
+"Plainsboro, District 3",350,164,13,4,5,3,4
+"Plainsboro, District 4",383,158,14,4,5,7,3
+"Plainsboro, District 5",617,229,14,9,5,11,3
+"Plainsboro, District 6",313,129,3,4,2,1,0
+"Plainsboro, District 7",269,87,1,1,1,1,2
+"Plainsboro, District 8",208,59,1,5,4,2,0
+"Plainsboro, District 9",337,139,20,5,4,7,7
+"Plainsboro, District 10",307,161,6,3,3,2,2
+"Plainsboro, District 11",147,43,5,4,3,2,0
+"Plainsboro, District 12",247,82,12,3,0,2,2
+"Plainsboro, District 13",330,115,7,4,2,3,1
+"South Brunswick, District 1",2268,1069,76,23,29,18,19
+"South Brunswick, District 2",320,182,10,5,2,2,1
+"South Brunswick, District 3",314,156,12,3,6,5,2
+"South Brunswick, District 4",233,286,11,5,4,2,2
+"South Brunswick, District 5",279,179,13,4,3,9,0
+"South Brunswick, District 6",198,187,10,2,2,0,5
+"South Brunswick, District 7",250,157,6,2,4,0,5
+"South Brunswick, District 8",261,194,7,5,4,5,0
+"South Brunswick, District 9",232,155,14,8,2,1,6
+"South Brunswick, District 10",175,150,9,4,4,4,2
+"South Brunswick, District 11",268,161,9,4,2,3,1
+"South Brunswick, District 12",187,128,11,4,3,3,5
+"South Brunswick, District 13",358,131,15,1,1,5,0
+"South Brunswick, District 14",292,110,12,4,3,1,1
+"South Brunswick, District 15",435,212,23,4,6,6,1
+"South Brunswick, District 16",544,221,8,9,0,1,1
+"South Brunswick, District 17",358,103,16,4,5,10,4
+"South Brunswick, District 18",358,141,9,5,3,1,2
+"South Brunswick, District 19",298,94,13,4,4,3,0
+"South Brunswick, District 20",236,121,11,4,1,8,1
+"South Brunswick, District 21",296,191,5,2,5,2,0
+"South Brunswick, District 22",381,172,18,4,4,1,0
+"South Brunswick, District 23",356,100,12,4,3,1,2
+"South Brunswick, District 24",227,162,11,9,5,3,1
+"South Brunswick, District 25",357,123,7,1,4,4,3
+"South Brunswick, District 26",454,266,14,11,3,2,4
+"South Brunswick, District 27",380,179,4,4,3,0,3
+"South Brunswick, District 28",474,192,7,5,4,2,6
+"South Brunswick, District 29",359,135,9,6,3,4,1
+"South Brunswick, District 30",320,109,17,4,0,1,2
+"South River, District 1",462,315,22,8,4,3,6
+"South River, District 2",131,110,9,1,1,1,1
+"South River, District 3",113,148,9,3,4,0,0
+"South River, District 4",109,136,3,4,1,1,0
+"South River, District 5",142,157,5,3,1,2,4
+"South River, District 6",162,148,6,2,2,1,2
+"South River, District 7",148,127,8,1,0,2,1
+"South River, District 8",121,152,12,3,3,0,2
+"South River, District 9",150,102,9,3,0,1,1
+"South River, District 10",322,239,7,3,3,3,0
+"South River, District 11",194,153,10,5,2,3,1
+"South River, District 12",176,124,16,6,4,2,2
+"South River, District 13",131,127,12,3,6,1,1
+"South River, District 14",123,144,10,6,3,3,3
+"Spotswood, District 1",439,537,53,18,21,3,7
+"Spotswood, District 2",130,232,11,7,8,2,1
+"Spotswood, District 3",124,173,11,4,4,1,2
+"Spotswood, District 4",148,179,11,6,3,2,6
+"Spotswood, District 5",194,253,22,16,4,4,8
+"Spotswood, District 6",138,168,11,5,1,4,3
+"Spotswood, District 7",110,251,11,5,4,3,3
+Total,68171,50192,2883,1319,891,703,572

--- a/2016/Middlesex/General/House Of Representatives 6th Congressional District - Middlesex County.csv
+++ b/2016/Middlesex/General/House Of Representatives 6th Congressional District - Middlesex County.csv
@@ -1,374 +1,375 @@
 District,"Frank PALLONE, Jr.",Brent SONNEK-SCHMELZ,Rajit B. MALLIAH,Judith SHAMY
-"Carteret, District 1",1027,230,3,7
-"Carteret, District 2",1145,262,4,6
-"Carteret, District 3",1121,207,4,7
-"Carteret, District 4",1054,212,3,8
-"Carteret, District 5",1035,270,3,8
-"Carteret, District 6",1029,236,6,12
-"Carteret, District 7",1017,267,3,7
-"Carteret, District 8",1116,247,4,6
-"Carteret, District 9",1015,286,3,8
-"Carteret, District 10",1005,288,3,8
-"Carteret, District 11",1071,304,2,7
-"Carteret, District 12",1051,309,4,7
-"Carteret, District 13",1037,279,3,7
-"Carteret, District 14",967,257,2,8
-"Carteret, District 15",1019,287,2,10
-"Carteret, District 16",986,268,3,8
-"Carteret, District 17",1057,284,2,10
-"Carteret, District 18",997,273,3,7
-"Carteret, District 19",969,256,2,7
-"Edison, District 1",3254,1308,25,27
-"Edison, District 2",3521,1235,31,27
-"Edison, District 3",3168,1246,25,29
-"Edison, District 4",3070,1219,23,26
-"Edison, District 5",3155,1223,27,26
-"Edison, District 6",3184,1170,26,29
-"Edison, District 7",3034,1164,27,29
-"Edison, District 8",3089,1192,27,28
-"Edison, District 9",3049,1175,23,27
-"Edison, District 10",3100,1234,26,28
-"Edison, District 11",3178,1225,25,33
-"Edison, District 12",3226,1234,26,28
-"Edison, District 13",3143,1174,26,26
-"Edison, District 14",3190,1291,26,31
-"Edison, District 15",3177,1235,25,28
-"Edison, District 16",3188,1250,25,30
-"Edison, District 17",3148,1201,27,29
-"Edison, District 18",3077,1186,24,26
-"Edison, District 19",3138,1206,24,28
-"Edison, District 20",3096,1177,24,27
-"Edison, District 21",3128,1217,23,28
-"Edison, District 22",3077,1205,23,26
-"Edison, District 23",3157,1229,24,31
-"Edison, District 24",3113,1202,27,30
-"Edison, District 25",3096,1174,26,29
-"Edison, District 26",3116,1221,24,30
-"Edison, District 27",3190,1362,26,31
-"Edison, District 28",3076,1119,23,26
-"Edison, District 29",3196,1215,27,27
-"Edison, District 30",3261,1291,26,27
-"Edison, District 31",3150,1230,29,29
-"Edison, District 32",3111,1182,24,27
-"Edison, District 33",3115,1202,27,31
-"Edison, District 34",3050,1203,23,28
-"Edison, District 35",3133,1219,27,27
-"Edison, District 36",3145,1178,23,27
-"Edison, District 37",3160,1243,26,28
-"Edison, District 38",3179,1177,23,30
-"Edison, District 39",3306,1149,25,33
-"Edison, District 40",3141,1198,29,27
-"Edison, District 41",3096,1174,27,29
-"Edison, District 42",3120,1146,26,26
-"Edison, District 43",3404,1189,33,27
-"Edison, District 44",3136,1254,28,29
-"Edison, District 45",3118,1210,24,27
-"Edison, District 46",3106,1187,24,28
-"Edison, District 47",3091,1193,25,33
-"Edison, District 48",3045,1170,23,30
-"Edison, District 49",3145,1232,24,29
-"Edison, District 50",3129,1215,27,27
-"Edison, District 51",3084,1172,25,26
-"Edison, District 52",3114,1198,25,28
-"Edison, District 53",3175,1219,24,29
-"Edison, District 54",3117,1198,24,26
-"Edison, District 55",3069,1168,23,26
-"Edison, District 56",3079,1183,24,31
-"Edison, District 57",3130,1203,25,27
-"Edison, District 58",3229,1150,26,26
-"Edison, District 59",3079,1184,24,27
-"Edison, District 60",3090,1193,25,32
-"Edison, District 61",3215,1234,27,28
-"Edison, District 62",3089,1234,26,29
-"Edison, District 63",3340,1201,28,34
-"Edison, District 64",3264,1248,27,29
-"Edison, District 65",3223,1237,31,28
-"Edison, District 66",3238,1239,27,27
-"Edison, District 67",3200,1272,24,26
-"Edison, District 68",3217,1300,25,29
-"Edison, District 69",3141,1185,24,26
-"Edison, District 70",3331,1248,26,27
-"Edison, District 71",3211,1196,27,27
-"Edison, District 72",3397,1298,28,27
-"Edison, District 73",3221,1262,23,28
-"Edison, District 74",3143,1221,25,27
-"Edison, District 75",3194,1148,26,27
-"Edison, District 76",3277,1229,23,26
-"Edison, District 77",3372,1199,26,29
-"Edison, District 78",3221,1143,27,26
-"Highland Park, District 1",1036,225,22,6
-"Highland Park, District 2",973,162,21,4
-"Highland Park, District 3",949,161,23,9
-"Highland Park, District 4",948,148,16,8
-"Highland Park, District 5",1023,208,20,9
-"Highland Park, District 6",996,155,21,5
-"Highland Park, District 7",1016,175,23,9
-"Highland Park, District 8",991,162,23,7
-"Highland Park, District 9",933,187,19,6
-"Highland Park, District 10",938,245,21,6
-"Highland Park, District 11",964,225,19,9
-"Highland Park, District 12",889,159,22,5
-"Highland Park, District 13",933,173,23,7
-"Metuchen, District 1",1001,527,13,11
-"Metuchen, District 2",1046,507,8,14
-"Metuchen, District 3",984,452,11,13
-"Metuchen, District 4",954,448,12,13
-"Metuchen, District 5",990,473,9,15
-"Metuchen, District 6",934,441,10,11
-"Metuchen, District 7",932,449,9,14
-"Metuchen, District 8",942,432,7,13
-"Metuchen, District 9",899,405,14,16
-"Metuchen, District 10",1085,520,7,14
-"Metuchen, District 11",1199,547,17,18
-"Metuchen, District 12",938,468,10,11
-"Metuchen, District 13",891,397,7,15
-"New Brunswick, Ward 1, District 1",919,136,14,15
-"New Brunswick, Ward 1, District 2",859,173,12,12
-"New Brunswick, Ward 1, District 3",903,131,11,14
-"New Brunswick, Ward 1, District 4",935,176,16,17
-"New Brunswick, Ward 1, District 5",951,219,12,17
-"New Brunswick, Ward 1, District 6",959,155,16,14
-"New Brunswick, Ward 2, District 1",1080,152,18,15
-"New Brunswick, Ward 2, District 2",835,122,16,12
-"New Brunswick, Ward 2, District 3",884,124,14,13
-"New Brunswick, Ward 2, District 4",852,133,12,16
-"New Brunswick, Ward 2, District 5",868,134,10,12
-"New Brunswick, Ward 2, District 6",807,140,11,13
-"New Brunswick, Ward 2, District 7",1195,153,15,15
-"New Brunswick, Ward 4, District 1",852,139,17,16
-"New Brunswick, Ward 4, District 2",1045,130,10,12
-"New Brunswick, Ward 4, District 3",836,121,10,12
-"New Brunswick, Ward 4, District 4",892,144,14,13
-"New Brunswick, Ward 4, District 5",872,127,10,14
-"New Brunswick, Ward 5, District 1",974,187,16,16
-"New Brunswick, Ward 5, District 2",760,123,16,13
-"New Brunswick, Ward 5, District 3",851,157,18,15
-"New Brunswick, Ward 5, District 4",804,143,11,12
-"New Brunswick, Ward 6, District 1",944,182,17,17
-"New Brunswick, Ward 6, District 2",746,151,14,12
-"New Brunswick, Ward 6, District 3",893,188,16,15
-"New Brunswick, Ward 6, District 4",871,175,16,15
-"New Brunswick, Ward 6, District 5",742,148,12,13
-"New Brunswick, Ward 6, District 6",881,174,14,14
-"Old Bridge, Ward 1, District 1",862,638,12,12
+"Carteret, District 1",1153,259,4,7
+"Carteret, District 2",368,79,2,0
+"Carteret, District 3",344,24,2,1
+"Carteret, District 4",277,29,1,2
+"Carteret, District 5",258,87,1,2
+"Carteret, District 6",252,53,4,6
+"Carteret, District 7",240,84,1,1
+"Carteret, District 8",339,64,2,0
+"Carteret, District 9",238,103,1,2
+"Carteret, District 10",228,105,1,2
+"Carteret, District 11",294,121,0,1
+"Carteret, District 12",274,126,2,1
+"Carteret, District 13",260,96,1,1
+"Carteret, District 14",190,74,0,2
+"Carteret, District 15",242,104,0,4
+"Carteret, District 16",209,85,1,2
+"Carteret, District 17",280,101,0,4
+"Carteret, District 18",220,90,1,1
+"Carteret, District 19",192,73,0,1
+"Edison, District 1",3759,1483,34,30
+"Edison, District 2",607,143,8,1
+"Edison, District 3",254,154,2,3
+"Edison, District 4",156,127,0,0
+"Edison, District 5",241,131,4,0
+"Edison, District 6",270,78,3,3
+"Edison, District 7",120,72,4,3
+"Edison, District 8",175,100,4,2
+"Edison, District 9",135,83,0,1
+"Edison, District 10",186,142,3,2
+"Edison, District 11",264,133,2,7
+"Edison, District 12",312,142,3,2
+"Edison, District 13",229,82,3,0
+"Edison, District 14",276,199,3,5
+"Edison, District 15",263,143,2,2
+"Edison, District 16",274,158,2,4
+"Edison, District 17",234,109,4,3
+"Edison, District 18",163,94,1,0
+"Edison, District 19",224,114,1,2
+"Edison, District 20",182,85,1,1
+"Edison, District 21",214,125,0,2
+"Edison, District 22",163,113,0,0
+"Edison, District 23",243,137,1,5
+"Edison, District 24",199,110,4,4
+"Edison, District 25",182,82,3,3
+"Edison, District 26",202,129,1,4
+"Edison, District 27",276,270,3,5
+"Edison, District 28",162,27,0,0
+"Edison, District 29",282,123,4,1
+"Edison, District 30",347,199,3,1
+"Edison, District 31",236,138,6,3
+"Edison, District 32",197,90,1,1
+"Edison, District 33",201,110,4,5
+"Edison, District 34",136,111,0,2
+"Edison, District 35",219,127,4,1
+"Edison, District 36",231,86,0,1
+"Edison, District 37",246,151,3,2
+"Edison, District 38",265,85,0,4
+"Edison, District 39",392,57,2,7
+"Edison, District 40",227,106,6,1
+"Edison, District 41",182,82,4,3
+"Edison, District 42",206,54,3,0
+"Edison, District 43",490,97,10,1
+"Edison, District 44",222,162,5,3
+"Edison, District 45",204,118,1,1
+"Edison, District 46",192,95,1,2
+"Edison, District 47",177,101,2,7
+"Edison, District 48",131,78,0,4
+"Edison, District 49",231,140,1,3
+"Edison, District 50",215,123,4,1
+"Edison, District 51",170,80,2,0
+"Edison, District 52",200,106,2,2
+"Edison, District 53",261,127,1,3
+"Edison, District 54",203,106,1,0
+"Edison, District 55",155,76,0,0
+"Edison, District 56",165,91,1,5
+"Edison, District 57",216,111,2,1
+"Edison, District 58",315,58,3,0
+"Edison, District 59",165,92,1,1
+"Edison, District 60",176,101,2,6
+"Edison, District 61",301,142,4,2
+"Edison, District 62",175,142,3,3
+"Edison, District 63",426,109,5,8
+"Edison, District 64",350,156,4,3
+"Edison, District 65",309,145,8,2
+"Edison, District 66",324,147,4,1
+"Edison, District 67",286,180,1,0
+"Edison, District 68",303,208,2,3
+"Edison, District 69",227,93,1,0
+"Edison, District 70",417,156,3,1
+"Edison, District 71",297,104,4,1
+"Edison, District 72",483,206,5,1
+"Edison, District 73",307,170,0,2
+"Edison, District 74",229,129,2,1
+"Edison, District 75",280,56,3,1
+"Edison, District 76",363,137,0,0
+"Edison, District 77",458,107,3,3
+"Edison, District 78",307,51,4,0
+"Highland Park, District 1",1174,282,27,8
+"Highland Park, District 2",311,56,5,0
+"Highland Park, District 3",287,55,7,5
+"Highland Park, District 4",286,42,0,4
+"Highland Park, District 5",361,102,4,5
+"Highland Park, District 6",334,49,5,1
+"Highland Park, District 7",354,69,7,5
+"Highland Park, District 8",329,56,7,3
+"Highland Park, District 9",271,81,3,2
+"Highland Park, District 10",276,139,5,2
+"Highland Park, District 11",302,119,3,5
+"Highland Park, District 12",227,53,6,1
+"Highland Park, District 13",271,67,7,3
+"Metuchen, District 1",1081,558,21,13
+"Metuchen, District 2",357,194,1,4
+"Metuchen, District 3",295,139,4,3
+"Metuchen, District 4",265,135,5,3
+"Metuchen, District 5",301,160,2,5
+"Metuchen, District 6",245,128,3,1
+"Metuchen, District 7",243,136,2,4
+"Metuchen, District 8",253,119,0,3
+"Metuchen, District 9",210,92,7,6
+"Metuchen, District 10",396,207,0,4
+"Metuchen, District 11",510,234,10,8
+"Metuchen, District 12",249,155,3,1
+"Metuchen, District 13",202,84,0,5
+"New Brunswick, Ward 1, District 1",1200,172,22,18
+"New Brunswick, Ward 1, District 2",226,63,2,0
+"New Brunswick, Ward 1, District 3",270,21,1,2
+"New Brunswick, Ward 1, District 4",302,66,6,5
+"New Brunswick, Ward 1, District 5",318,109,2,5
+"New Brunswick, Ward 1, District 6",326,45,6,2
+"New Brunswick, Ward 2, District 1",447,42,8,3
+"New Brunswick, Ward 2, District 2",202,12,6,0
+"New Brunswick, Ward 2, District 3",251,14,4,1
+"New Brunswick, Ward 2, District 4",219,23,2,4
+"New Brunswick, Ward 2, District 5",235,24,0,0
+"New Brunswick, Ward 2, District 6",174,30,1,1
+"New Brunswick, Ward 2, District 7",562,43,5,3
+"New Brunswick, Ward 4, District 1",219,29,7,4
+"New Brunswick, Ward 4, District 2",412,20,0,0
+"New Brunswick, Ward 4, District 3",203,11,0,0
+"New Brunswick, Ward 4, District 4",259,34,4,1
+"New Brunswick, Ward 4, District 5",239,17,0,2
+"New Brunswick, Ward 5, District 1",341,77,6,4
+"New Brunswick, Ward 5, District 2",127,13,6,1
+"New Brunswick, Ward 5, District 3",218,47,8,3
+"New Brunswick, Ward 5, District 4",171,33,1,0
+"New Brunswick, Ward 6, District 1",311,72,7,5
+"New Brunswick, Ward 6, District 2",113,41,4,0
+"New Brunswick, Ward 6, District 3",260,78,6,3
+"New Brunswick, Ward 6, District 4",238,65,6,3
+"New Brunswick, Ward 6, District 5",109,38,2,1
+"New Brunswick, Ward 6, District 6",248,64,4,2
+"Old Bridge, Ward 1, District 1",281,214,2,2
 "Old Bridge, Ward 1, District 2",866,628,12,12
-"Old Bridge, Ward 1, District 3",880,642,14,17
-"Old Bridge, Ward 1, District 4",864,640,13,12
-"Old Bridge, Ward 1, District 5",1228,802,17,16
-"Old Bridge, Ward 1, District 6",821,619,13,10
-"Old Bridge, Ward 1, District 7",785,608,11,10
-"Old Bridge, Ward 1, District 8",1071,877,10,15
-"Old Bridge, Ward 1, District 9",840,642,11,18
-"Old Bridge, Ward 2, District 1",759,573,12,11
-"Old Bridge, Ward 2, District 2",1114,829,14,12
-"Old Bridge, Ward 2, District 3",1015,801,14,13
-"Old Bridge, Ward 2, District 4",1087,696,15,13
-"Old Bridge, Ward 2, District 5",1024,850,10,11
-"Old Bridge, Ward 4, District 3",999,801,11,15
-"Old Bridge, Ward 4, District 6",981,735,14,13
-"Perth Amboy, Ward 1, District 1",1636,206,17,12
-"Perth Amboy, Ward 1, District 2",1694,189,14,9
-"Perth Amboy, Ward 1, District 3",1740,197,18,14
-"Perth Amboy, Ward 1, District 4",1638,193,15,9
-"Perth Amboy, Ward 1, District 5",1676,191,17,10
-"Perth Amboy, Ward 2, District 1",1826,224,20,10
-"Perth Amboy, Ward 2, District 2",1784,219,19,10
-"Perth Amboy, Ward 3, District 1",1624,186,16,9
-"Perth Amboy, Ward 3, District 2",1643,190,15,9
-"Perth Amboy, Ward 4, District 1",1604,188,15,10
-"Perth Amboy, Ward 4, District 2",1706,186,16,11
-"Perth Amboy, Ward 4, District 3",1671,183,14,10
-"Perth Amboy, Ward 4, District 4",1657,187,14,10
-"Perth Amboy, Ward 4, District 5",1736,203,15,9
-"Perth Amboy, Ward 4, District 6",1727,216,18,11
-"Perth Amboy, Ward 5, District 1",1674,186,14,10
-"Perth Amboy, Ward 5, District 2",1786,207,18,11
-"Perth Amboy, Ward 5, District 3",1962,205,16,12
-"Perth Amboy, Ward 6, District 1",1629,178,15,12
-"Perth Amboy, Ward 6, District 2",1698,196,16,9
-"Perth Amboy, Ward 6, District 3",1762,214,14,9
-"Perth Amboy, Ward 6, District 4",1806,226,17,9
-"Perth Amboy, Ward 6, District 5",1730,241,17,10
-"Perth Amboy, Ward 6, District 6",1695,205,14,9
-"Perth Amboy, Ward 6, District 7",1712,209,19,10
-"Perth Amboy, Ward 6, District 8",1658,183,14,9
-"Perth Amboy, Ward 6, District 9",1836,221,18,9
-"Perth Amboy, Ward 6, District 10",1771,206,15,11
-"Perth Amboy, Ward 6, District 11",1730,212,17,10
-"Perth Amboy, Ward 6, District 12",1791,224,16,9
-"Perth Amboy, Ward 6, District 13",1836,248,19,10
-"Perth Amboy, Ward 6, District 14",1737,194,17,10
-"Piscataway, Ward 1, District 1",1975,541,32,14
-"Piscataway, Ward 1, District 2",1745,575,31,13
-"Piscataway, Ward 1, District 3",1867,604,29,13
-"Piscataway, Ward 1, District 4",1783,618,33,16
-"Piscataway, Ward 1, District 5",1830,664,33,18
-"Piscataway, Ward 1, District 6",1733,662,30,13
-"Piscataway, Ward 1, District 7",2070,611,34,17
-"Piscataway, Ward 1, District 8",1756,667,30,13
-"Piscataway, Ward 1, District 9",1692,620,29,15
-"Piscataway, Ward 2, District 1",1744,617,30,14
-"Piscataway, Ward 2, District 2",1715,639,31,12
-"Piscataway, Ward 2, District 3",1954,657,29,14
-"Piscataway, Ward 2, District 4",1707,636,36,12
-"Piscataway, Ward 2, District 5",1738,580,32,13
-"Piscataway, Ward 2, District 6",1888,698,33,19
-"Piscataway, Ward 2, District 7",1940,676,32,14
-"Piscataway, Ward 2, District 8",1808,562,30,15
-"Piscataway, Ward 2, District 9",1764,600,33,16
-"Piscataway, Ward 2, District 10",2072,652,32,13
-"Piscataway, Ward 3, District 1",1791,702,32,13
-"Piscataway, Ward 3, District 2",1840,655,32,16
-"Piscataway, Ward 3, District 3",1748,643,29,13
-"Piscataway, Ward 3, District 4",1985,567,32,14
-"Piscataway, Ward 3, District 5",1735,576,31,16
-"Piscataway, Ward 3, District 6",1705,554,30,14
-"Piscataway, Ward 3, District 7",1810,597,34,14
-"Piscataway, Ward 3, District 8",1870,636,31,15
-"Piscataway, Ward 3, District 9",1681,571,34,14
-"Piscataway, Ward 3, District 10",1727,646,32,12
-"Piscataway, Ward 4, District 1",1657,596,29,12
-"Piscataway, Ward 4, District 2",1710,543,31,16
-"Piscataway, Ward 4, District 3",1657,565,29,12
-"Piscataway, Ward 4, District 4",1735,569,36,15
-"Piscataway, Ward 4, District 5",1974,619,35,12
-"Piscataway, Ward 4, District 6",1829,580,35,15
-"Piscataway, Ward 4, District 7",1853,606,38,13
-"Piscataway, Ward 4, District 8",1779,643,33,15
-"Piscataway, Ward 4, District 9",1712,554,30,13
-"Piscataway, Ward 4, District 10",1662,582,33,15
-"Sayreville, District 1",1095,669,9,17
-"Sayreville, District 2",1265,778,12,21
-"Sayreville, District 3",1344,822,15,15
-"Sayreville, District 4",1116,758,10,17
-"Sayreville, District 5",1132,737,11,16
-"Sayreville, District 6",1018,675,10,17
-"Sayreville, District 7",1092,700,11,21
-"Sayreville, District 8",1051,701,10,14
-"Sayreville, District 9",1029,705,10,16
-"Sayreville, District 10",1234,730,10,17
-"Sayreville, District 11",1186,784,12,19
-"Sayreville, District 12",1261,815,16,18
-"Sayreville, District 13",1111,759,11,16
-"Sayreville, District 14",1087,717,12,16
-"Sayreville, District 15",1114,744,10,14
-"Sayreville, District 16",1122,742,10,17
-"Sayreville, District 17",1027,660,9,17
-"Sayreville, District 18",1135,755,9,18
-"Sayreville, District 19",1040,672,9,15
-"Sayreville, District 20",1154,653,12,14
-"Sayreville, District 21",1112,712,9,17
-"Sayreville, District 22",1063,717,10,15
-"Sayreville, District 23",1062,695,11,14
-"Sayreville, District 24",1104,796,9,16
-"Sayreville, District 25",1097,752,11,17
-"Sayreville, District 26",1180,742,11,15
-"Sayreville, District 27",1247,735,14,18
-"Sayreville, District 28",1223,709,11,16
-"Sayreville, District 29",1034,694,10,14
-"Sayreville, District 30",1359,795,12,19
-"Sayreville, District 31",1311,746,12,20
-"Sayreville, District 32",1173,748,11,16
-"Sayreville, District 33",1456,647,14,15
-"Sayreville, District 34",1211,690,19,14
-"Sayreville, District 35",1149,719,9,18
-"South Amboy, Ward 1, District 1",202,123,0,3
-"South Amboy, Ward 1, District 2",251,149,2,3
-"South Amboy, Ward 1, District 3",280,181,5,3
-"South Amboy, Ward 2, District 1",190,114,4,5
-"South Amboy, Ward 2, District 2",172,117,3,2
-"South Amboy, Ward 2, District 3",233,117,6,3
-"South Amboy, Ward 3, District 1",217,116,2,2
-"South Amboy, Ward 3, District 2",424,284,5,4
-"South Amboy, Ward 3, District 3",309,238,2,4
-"South Plainfield, District 1",861,477,11,9
-"South Plainfield, District 2",800,565,10,6
-"South Plainfield, District 3",823,516,11,6
-"South Plainfield, District 4",989,677,9,3
-"South Plainfield, District 5",734,514,9,6
-"South Plainfield, District 6",831,547,10,3
-"South Plainfield, District 7",920,545,11,5
-"South Plainfield, District 8",845,564,11,4
-"South Plainfield, District 9",792,568,11,4
-"South Plainfield, District 10",1092,576,15,6
-"South Plainfield, District 11",773,514,11,7
-"South Plainfield, District 12",752,548,13,4
-"South Plainfield, District 13",926,563,10,8
-"South Plainfield, District 14",829,608,10,3
-"South Plainfield, District 15",972,467,13,5
-"Woodbridge, Ward 1, District 1",2246,1095,27,32
-"Woodbridge, Ward 1, District 2",2219,1166,23,38
-"Woodbridge, Ward 1, District 3",2231,1093,23,33
-"Woodbridge, Ward 1, District 4",2263,1146,22,34
-"Woodbridge, Ward 1, District 5",2245,1123,21,33
-"Woodbridge, Ward 1, District 6",2172,1069,23,36
-"Woodbridge, Ward 1, District 7",2384,1172,24,34
-"Woodbridge, Ward 1, District 8",2120,1022,23,30
-"Woodbridge, Ward 1, District 9",2192,1119,24,32
-"Woodbridge, Ward 1, District 10",2317,1142,23,33
-"Woodbridge, Ward 1, District 11",2197,1115,23,34
-"Woodbridge, Ward 1, District 12",2299,1059,23,33
-"Woodbridge, Ward 1, District 13",2349,1168,29,35
-"Woodbridge, Ward 1, District 14",2253,1077,23,31
-"Woodbridge, Ward 1, District 15",2210,1139,24,33
-"Woodbridge, Ward 2, District 1",2162,1009,22,32
-"Woodbridge, Ward 2, District 2",2186,1083,23,32
-"Woodbridge, Ward 2, District 3",2240,1111,27,31
-"Woodbridge, Ward 2, District 4",2207,1139,26,33
-"Woodbridge, Ward 2, District 5",2183,1084,24,37
-"Woodbridge, Ward 2, District 6",2206,1073,21,31
-"Woodbridge, Ward 2, District 7",2247,1093,23,32
-"Woodbridge, Ward 2, District 8",2314,1143,24,35
-"Woodbridge, Ward 2, District 9",2206,1141,24,33
-"Woodbridge, Ward 2, District 10",2190,1079,26,32
-"Woodbridge, Ward 2, District 11",2215,1091,23,39
-"Woodbridge, Ward 2, District 12",2244,1124,23,31
-"Woodbridge, Ward 2, District 13",2355,1104,23,31
-"Woodbridge, Ward 2, District 14",2315,1030,21,30
-"Woodbridge, Ward 2, District 15",2230,1047,22,30
-"Woodbridge, Ward 3, District 1",2149,1078,24,32
-"Woodbridge, Ward 3, District 2",2321,1161,24,33
-"Woodbridge, Ward 3, District 3",2173,1121,22,34
-"Woodbridge, Ward 3, District 4",2135,1075,23,32
-"Woodbridge, Ward 3, District 5",2198,1100,23,31
-"Woodbridge, Ward 3, District 6",2241,1077,21,35
-"Woodbridge, Ward 3, District 7",2215,1116,21,31
-"Woodbridge, Ward 3, District 8",2203,1047,23,36
-"Woodbridge, Ward 3, District 9",2218,1100,27,31
-"Woodbridge, Ward 3, District 10",2419,1111,26,35
-"Woodbridge, Ward 3, District 11",2294,1000,21,31
-"Woodbridge, Ward 3, District 12",2352,1031,24,30
-"Woodbridge, Ward 3, District 13",2298,1138,22,35
-"Woodbridge, Ward 4, District 1",2947,1303,28,34
-"Woodbridge, Ward 4, District 2",2731,1332,28,38
-"Woodbridge, Ward 4, District 3",2673,1263,26,35
-"Woodbridge, Ward 4, District 4",2629,1252,28,35
-"Woodbridge, Ward 4, District 5",2714,1274,30,36
-"Woodbridge, Ward 4, District 6",2640,1277,26,34
-"Woodbridge, Ward 4, District 7",2810,1337,31,38
-"Woodbridge, Ward 4, District 8",2759,1312,30,38
-"Woodbridge, Ward 4, District 9",2826,1329,29,35
-"Woodbridge, Ward 4, District 10",2839,1300,28,39
-"Woodbridge, Ward 4, District 11",2757,1262,28,38
-"Woodbridge, Ward 4, District 12",2671,1242,28,34
-"Woodbridge, Ward 4, District 13",2653,1278,28,37
-"Woodbridge, Ward 4, District 14",2706,1283,27,35
-"Woodbridge, Ward 5, District 1",2158,1165,23,33
-"Woodbridge, Ward 5, District 2",2178,1068,23,34
-"Woodbridge, Ward 5, District 3",2151,1104,23,33
-"Woodbridge, Ward 5, District 4",2161,1118,22,35
-"Woodbridge, Ward 5, District 5",2272,1160,21,35
-"Woodbridge, Ward 5, District 6",2287,1145,24,35
-"Woodbridge, Ward 5, District 7",2264,1195,23,35
-"Woodbridge, Ward 5, District 8",2216,1162,23,33
-"Woodbridge, Ward 5, District 9",2341,1111,27,35
-"Woodbridge, Ward 5, District 10",2246,1199,23,33
-"Woodbridge, Ward 5, District 11",2214,1142,23,32
-"Woodbridge, Ward 5, District 12",2240,1198,26,32
-"Woodbridge, Ward 5, District 13",2195,1139,21,35
-"Woodbridge, Ward 5, District 14",2200,1116,24,31
-"Woodbridge, Ward 5, District 15",2165,1077,25,31
-"Woodbridge, Ward 5, District 16",2280,1184,25,33
-"Woodbridge, Ward 5, District 17",2187,1144,24,35
-"Woodbridge, Ward 5, District 18",2129,1084,21,31
-Total,687922,274907,7223,7302
+"Old Bridge, Ward 1, District 3",201,160,4,7
+"Old Bridge, Ward 1, District 4",185,158,3,2
+"Old Bridge, Ward 1, District 5",549,320,7,6
+"Old Bridge, Ward 1, District 6",142,137,3,0
+"Old Bridge, Ward 1, District 7",106,126,1,0
+"Old Bridge, Ward 1, District 8",392,395,0,5
+"Old Bridge, Ward 1, District 9",161,160,1,8
+"Old Bridge, Ward 2, District 1",80,91,2,1
+"Old Bridge, Ward 2, District 2",435,347,4,2
+"Old Bridge, Ward 2, District 3",336,319,4,3
+"Old Bridge, Ward 2, District 4",408,214,5,3
+"Old Bridge, Ward 2, District 5",345,368,0,1
+"Old Bridge, Ward 2, District 8",202,233,4,3
+"Old Bridge, Ward 4, District 3",320,319,1,5
+"Old Bridge, Ward 4, District 6",302,253,4,3
+"Perth Amboy, Ward 1, District 1",2329,268,22,17
+"Perth Amboy, Ward 1, District 2",199,24,0,0
+"Perth Amboy, Ward 1, District 3",245,32,4,5
+"Perth Amboy, Ward 1, District 4",143,28,1,0
+"Perth Amboy, Ward 1, District 5",181,26,3,1
+"Perth Amboy, Ward 2, District 1",331,59,6,1
+"Perth Amboy, Ward 2, District 2",289,54,5,1
+"Perth Amboy, Ward 3, District 1",129,21,2,0
+"Perth Amboy, Ward 3, District 2",148,25,1,0
+"Perth Amboy, Ward 4, District 1",109,23,1,1
+"Perth Amboy, Ward 4, District 2",211,21,2,2
+"Perth Amboy, Ward 4, District 3",176,18,0,1
+"Perth Amboy, Ward 4, District 4",162,22,0,1
+"Perth Amboy, Ward 4, District 5",241,38,1,0
+"Perth Amboy, Ward 4, District 6",232,51,4,2
+"Perth Amboy, Ward 5, District 1",179,21,0,1
+"Perth Amboy, Ward 5, District 2",291,42,4,2
+"Perth Amboy, Ward 5, District 3",467,40,2,3
+"Perth Amboy, Ward 6, District 1",134,13,1,3
+"Perth Amboy, Ward 6, District 2",203,31,2,0
+"Perth Amboy, Ward 6, District 3",267,49,0,0
+"Perth Amboy, Ward 6, District 4",311,61,3,0
+"Perth Amboy, Ward 6, District 5",235,76,3,1
+"Perth Amboy, Ward 6, District 6",200,40,0,0
+"Perth Amboy, Ward 6, District 7",217,44,5,1
+"Perth Amboy, Ward 6, District 8",163,18,0,0
+"Perth Amboy, Ward 6, District 9",341,56,4,0
+"Perth Amboy, Ward 6, District 10",276,41,1,2
+"Perth Amboy, Ward 6, District 11",235,47,3,1
+"Perth Amboy, Ward 6, District 12",296,59,2,0
+"Perth Amboy, Ward 6, District 13",341,83,5,1
+"Perth Amboy, Ward 6, District 14",242,29,3,1
+"Piscataway, Ward 1, District 1",2316,607,39,17
+"Piscataway, Ward 1, District 2",294,68,2,1
+"Piscataway, Ward 1, District 3",416,97,0,1
+"Piscataway, Ward 1, District 4",332,111,4,4
+"Piscataway, Ward 1, District 5",379,157,4,6
+"Piscataway, Ward 1, District 6",282,155,1,1
+"Piscataway, Ward 1, District 7",619,104,5,5
+"Piscataway, Ward 1, District 8",305,160,1,1
+"Piscataway, Ward 1, District 9",241,113,0,3
+"Piscataway, Ward 2, District 1",293,110,1,2
+"Piscataway, Ward 2, District 2",264,132,2,0
+"Piscataway, Ward 2, District 3",503,150,0,2
+"Piscataway, Ward 2, District 4",256,129,7,0
+"Piscataway, Ward 2, District 5",287,73,3,1
+"Piscataway, Ward 2, District 6",437,191,4,7
+"Piscataway, Ward 2, District 7",489,169,3,2
+"Piscataway, Ward 2, District 8",357,55,1,3
+"Piscataway, Ward 2, District 9",313,93,4,4
+"Piscataway, Ward 2, District 10",621,145,3,1
+"Piscataway, Ward 3, District 1",340,195,3,1
+"Piscataway, Ward 3, District 2",389,148,3,4
+"Piscataway, Ward 3, District 3",297,136,0,1
+"Piscataway, Ward 3, District 4",534,60,3,2
+"Piscataway, Ward 3, District 5",284,69,2,4
+"Piscataway, Ward 3, District 6",254,47,1,2
+"Piscataway, Ward 3, District 7",359,90,5,2
+"Piscataway, Ward 3, District 8",419,129,2,3
+"Piscataway, Ward 3, District 9",230,64,5,2
+"Piscataway, Ward 3, District 10",276,139,3,0
+"Piscataway, Ward 4, District 1",206,89,0,0
+"Piscataway, Ward 4, District 2",259,36,2,4
+"Piscataway, Ward 4, District 3",206,58,0,0
+"Piscataway, Ward 4, District 4",284,62,7,3
+"Piscataway, Ward 4, District 5",523,112,6,0
+"Piscataway, Ward 4, District 6",378,73,6,3
+"Piscataway, Ward 4, District 7",402,99,9,1
+"Piscataway, Ward 4, District 8",328,136,4,3
+"Piscataway, Ward 4, District 9",261,47,1,1
+"Piscataway, Ward 4, District 10",211,75,4,3
+"Sayreville, District 1",1239,760,10,19
+"Sayreville, District 2",366,215,3,7
+"Sayreville, District 3",445,259,6,1
+"Sayreville, District 4",217,195,1,3
+"Sayreville, District 5",233,174,2,2
+"Sayreville, District 6",119,112,1,3
+"Sayreville, District 7",193,137,2,7
+"Sayreville, District 8",152,138,1,0
+"Sayreville, District 9",130,142,1,2
+"Sayreville, District 10",335,167,1,3
+"Sayreville, District 11",287,221,3,5
+"Sayreville, District 12",362,252,7,4
+"Sayreville, District 13",212,196,2,2
+"Sayreville, District 14",188,154,3,2
+"Sayreville, District 15",215,181,1,0
+"Sayreville, District 16",223,179,1,3
+"Sayreville, District 17",128,97,0,3
+"Sayreville, District 18",236,192,0,4
+"Sayreville, District 19",141,109,0,1
+"Sayreville, District 20",255,90,3,0
+"Sayreville, District 21",213,149,0,3
+"Sayreville, District 22",164,154,1,1
+"Sayreville, District 23",163,132,2,0
+"Sayreville, District 24",205,233,0,2
+"Sayreville, District 25",198,189,2,3
+"Sayreville, District 26",281,179,2,1
+"Sayreville, District 27",348,172,5,4
+"Sayreville, District 28",324,146,2,2
+"Sayreville, District 29",135,131,1,0
+"Sayreville, District 30",460,232,3,5
+"Sayreville, District 31",412,183,3,6
+"Sayreville, District 32",274,185,2,2
+"Sayreville, District 33",557,84,5,1
+"Sayreville, District 34",312,127,10,0
+"Sayreville, District 35",250,156,0,4
+"South Amboy, Ward 1, District 1",209,129,0,3
+"South Amboy, Ward 1, District 2",191,115,2,2
+"South Amboy, Ward 1, District 3",220,147,5,2
+"South Amboy, Ward 2, District 1",201,120,4,5
+"South Amboy, Ward 2, District 2",140,102,2,1
+"South Amboy, Ward 2, District 3",201,102,5,2
+"South Amboy, Ward 3, District 1",227,123,2,2
+"South Amboy, Ward 3, District 2",297,216,3,3
+"South Amboy, Ward 3, District 3",182,170,0,3
+"South Plainfield, District 1",934,514,12,9
+"South Plainfield, District 2",276,251,2,4
+"South Plainfield, District 3",299,202,3,4
+"South Plainfield, District 4",465,363,1,1
+"South Plainfield, District 5",210,200,1,4
+"South Plainfield, District 6",307,233,2,1
+"South Plainfield, District 7",396,231,3,3
+"South Plainfield, District 8",321,250,3,2
+"South Plainfield, District 9",268,254,3,2
+"South Plainfield, District 10",568,262,7,4
+"South Plainfield, District 11",249,200,3,5
+"South Plainfield, District 12",228,234,5,2
+"South Plainfield, District 13",402,249,2,6
+"South Plainfield, District 14",305,294,2,1
+"South Plainfield, District 15",448,153,5,3
+"Woodbridge, Ward 1, District 1",2542,1240,31,40
+"Woodbridge, Ward 1, District 2",238,197,2,8
+"Woodbridge, Ward 1, District 3",250,124,2,3
+"Woodbridge, Ward 1, District 4",282,177,1,4
+"Woodbridge, Ward 1, District 5",264,154,0,3
+"Woodbridge, Ward 1, District 6",191,100,2,6
+"Woodbridge, Ward 1, District 7",403,203,3,4
+"Woodbridge, Ward 1, District 8",139,53,2,0
+"Woodbridge, Ward 1, District 9",211,150,3,2
+"Woodbridge, Ward 1, District 10",336,173,2,3
+"Woodbridge, Ward 1, District 11",216,146,2,4
+"Woodbridge, Ward 1, District 12",318,90,2,3
+"Woodbridge, Ward 1, District 13",368,199,8,5
+"Woodbridge, Ward 1, District 14",272,108,2,1
+"Woodbridge, Ward 1, District 15",229,170,3,3
+"Woodbridge, Ward 2, District 1",181,40,1,2
+"Woodbridge, Ward 2, District 2",205,114,2,2
+"Woodbridge, Ward 2, District 3",259,142,6,1
+"Woodbridge, Ward 2, District 4",226,170,5,3
+"Woodbridge, Ward 2, District 5",202,115,3,7
+"Woodbridge, Ward 2, District 6",225,104,0,1
+"Woodbridge, Ward 2, District 7",266,124,2,2
+"Woodbridge, Ward 2, District 8",333,174,3,5
+"Woodbridge, Ward 2, District 9",225,172,3,3
+"Woodbridge, Ward 2, District 10",209,110,5,2
+"Woodbridge, Ward 2, District 11",234,122,2,9
+"Woodbridge, Ward 2, District 12",263,155,2,1
+"Woodbridge, Ward 2, District 13",374,135,2,1
+"Woodbridge, Ward 2, District 14",334,61,0,0
+"Woodbridge, Ward 2, District 15",249,78,1,0
+"Woodbridge, Ward 3, District 1",168,109,3,2
+"Woodbridge, Ward 3, District 2",340,192,3,3
+"Woodbridge, Ward 3, District 3",192,152,1,4
+"Woodbridge, Ward 3, District 4",154,106,2,2
+"Woodbridge, Ward 3, District 5",217,131,2,1
+"Woodbridge, Ward 3, District 6",260,108,0,5
+"Woodbridge, Ward 3, District 7",234,147,0,1
+"Woodbridge, Ward 3, District 8",222,78,2,6
+"Woodbridge, Ward 3, District 9",237,131,6,1
+"Woodbridge, Ward 3, District 10",438,142,5,5
+"Woodbridge, Ward 3, District 11",313,31,0,1
+"Woodbridge, Ward 3, District 12",371,62,3,0
+"Woodbridge, Ward 3, District 13",317,169,1,5
+"Woodbridge, Ward 4, District 1",1070,354,9,5
+"Woodbridge, Ward 4, District 2",276,159,2,4
+"Woodbridge, Ward 4, District 3",218,90,0,1
+"Woodbridge, Ward 4, District 4",174,79,2,1
+"Woodbridge, Ward 4, District 5",259,101,4,2
+"Woodbridge, Ward 4, District 6",185,104,0,0
+"Woodbridge, Ward 4, District 7",355,164,5,4
+"Woodbridge, Ward 4, District 8",304,139,4,4
+"Woodbridge, Ward 4, District 9",371,156,3,1
+"Woodbridge, Ward 4, District 10",384,127,2,5
+"Woodbridge, Ward 4, District 11",302,89,2,4
+"Woodbridge, Ward 4, District 12",216,69,2,0
+"Woodbridge, Ward 4, District 13",198,105,2,3
+"Woodbridge, Ward 4, District 14",251,110,1,1
+"Woodbridge, Ward 5, District 1",177,196,2,3
+"Woodbridge, Ward 5, District 2",197,99,2,4
+"Woodbridge, Ward 5, District 3",170,135,2,3
+"Woodbridge, Ward 5, District 4",180,149,1,5
+"Woodbridge, Ward 5, District 5",291,191,0,5
+"Woodbridge, Ward 5, District 6",306,176,3,5
+"Woodbridge, Ward 5, District 7",283,226,2,5
+"Woodbridge, Ward 5, District 8",235,193,2,3
+"Woodbridge, Ward 5, District 9",360,142,6,5
+"Woodbridge, Ward 5, District 10",265,230,2,3
+"Woodbridge, Ward 5, District 11",233,173,2,2
+"Woodbridge, Ward 5, District 12",259,229,5,2
+"Woodbridge, Ward 5, District 13",214,170,0,5
+"Woodbridge, Ward 5, District 14",219,147,3,1
+"Woodbridge, Ward 5, District 15",184,108,4,1
+"Woodbridge, Ward 5, District 16",299,215,4,3
+"Woodbridge, Ward 5, District 17",206,175,3,5
+"Woodbridge, Ward 5, District 18",148,115,0,1
+Total,116600,50849,1196,1065

--- a/2016/Middlesex/General/Presidential Electors - Middlesex County.csv
+++ b/2016/Middlesex/General/Presidential Electors - Middlesex County.csv
@@ -1,611 +1,617 @@
 District,Hillary Rodham CLINTON,Donald J. TRUMP,Gary JOHNSON,Jill STEIN,Alyson KENNEDY,Darrell CASTLE,Monica MOOREHEAD,Rocky Roque De La FUENTE,Gloria La RIVA
-"Carteret, District 1",1036,291,12,5,1,2,0,0,0
-"Carteret, District 2",1145,340,15,6,1,2,0,0,0
-"Carteret, District 3",1134,265,10,6,1,2,0,0,0
-"Carteret, District 4",1076,272,10,2,1,2,0,0,2
-"Carteret, District 5",1026,360,14,2,2,2,1,0,0
-"Carteret, District 6",1028,315,12,5,1,3,1,0,0
-"Carteret, District 7",1010,337,12,5,3,2,1,0,1
-"Carteret, District 8",1135,321,11,4,4,5,0,0,0
-"Carteret, District 9",1007,360,10,5,3,2,0,0,1
-"Carteret, District 10",987,377,14,1,1,2,0,0,0
-"Carteret, District 11",1066,382,13,4,2,2,0,0,0
-"Carteret, District 12",1024,416,16,5,1,2,0,0,0
-"Carteret, District 13",1006,375,13,4,2,2,0,0,0
-"Carteret, District 14",950,347,10,3,1,3,0,0,0
-"Carteret, District 15",982,390,13,1,3,2,0,0,0
-"Carteret, District 16",978,347,11,2,1,3,0,0,0
-"Carteret, District 17",1042,392,15,6,3,2,0,0,0
-"Carteret, District 18",974,361,11,3,1,3,0,0,0
-"Carteret, District 19",942,344,11,3,1,2,0,0,0
-"Cranbury, District 1",550,308,31,9,2,2,1,0,0
-"Cranbury, District 2",576,373,33,7,3,6,1,0,0
-"Cranbury, District 3",508,296,21,10,2,3,0,0,0
-"Dunellen, District 1",333,228,16,6,0,0,0,1,0
-"Dunellen, District 2",483,304,18,15,1,1,2,0,2
-"Dunellen, District 3",249,283,23,8,1,0,0,0,0
-"Dunellen, District 4",316,219,21,8,1,0,0,0,0
-"Dunellen, District 5",370,315,23,6,2,1,1,3,0
-"Dunellen, District 6",261,236,15,8,0,0,0,0,0
-"East Brunswick, District 1",2418,1381,91,40,1,6,2,0,3
-"East Brunswick, District 2",2621,1473,95,49,1,8,1,1,3
-"East Brunswick, District 3",2247,1368,88,42,0,8,1,1,3
-"East Brunswick, District 4",2311,1372,89,41,0,6,1,0,3
-"East Brunswick, District 5",2152,1229,84,42,0,9,1,0,4
-"East Brunswick, District 6",2145,1287,85,40,0,7,1,0,4
-"East Brunswick, District 7",2247,1365,89,39,2,7,2,0,3
-"East Brunswick, District 8",2230,1340,87,43,0,6,1,1,4
-"East Brunswick, District 9",2209,1337,93,39,3,8,1,0,3
-"East Brunswick, District 10",2253,1282,94,39,0,9,1,0,3
-"East Brunswick, District 11",2135,1265,86,39,0,7,2,0,3
-"East Brunswick, District 12",2219,1326,92,41,3,7,1,0,3
-"East Brunswick, District 13",2285,1335,91,41,1,7,1,0,3
-"East Brunswick, District 14",2407,1397,97,44,2,8,2,0,3
-"East Brunswick, District 15",2186,1250,83,38,0,6,1,0,3
-"East Brunswick, District 16",2285,1364,90,41,2,6,1,0,3
-"East Brunswick, District 17",2269,1310,86,40,0,6,1,1,3
-"East Brunswick, District 18",2191,1238,85,40,2,6,1,2,3
-"East Brunswick, District 19",2189,1258,95,42,0,7,1,2,3
-"East Brunswick, District 20",2375,1400,92,39,1,7,1,0,3
-"East Brunswick, District 21",2254,1329,85,44,0,6,1,0,3
-"East Brunswick, District 22",2226,1273,91,39,0,7,2,0,3
-"East Brunswick, District 23",2328,1345,98,40,1,8,1,0,3
-"East Brunswick, District 24",2243,1329,88,40,0,6,1,0,3
-"East Brunswick, District 25",2240,1288,84,41,0,7,1,0,3
-"East Brunswick, District 26",2320,1421,91,41,0,8,1,1,3
-"East Brunswick, District 27",2215,1401,91,42,1,6,1,1,3
-"East Brunswick, District 28",2152,1270,87,41,0,6,2,0,3
-"East Brunswick, District 29",2284,1331,97,39,1,6,1,1,3
-"East Brunswick, District 30",2305,1351,83,42,0,6,1,1,3
-"East Brunswick, District 31",2335,1409,90,47,0,6,1,0,3
-"East Brunswick, District 32",2218,1261,86,42,0,7,1,1,3
-"East Brunswick, District 33",2252,1259,92,41,1,7,1,0,4
-"East Brunswick, District 34",2374,1373,91,45,1,6,2,0,3
-"East Brunswick, District 35",2151,1249,87,43,1,6,1,0,3
-"East Brunswick, District 36",2281,1333,89,39,0,6,1,1,3
-"East Brunswick, District 37",2351,1352,95,42,1,7,1,0,3
-"East Brunswick, District 38",2234,1308,87,44,2,6,2,0,3
-"East Brunswick, District 39",2227,1307,88,45,0,7,1,0,3
-"East Brunswick, District 40",2308,1322,87,39,0,6,1,0,3
-"Edison, District 1",3237,1525,71,39,1,12,1,1,2
-"Edison, District 2",3494,1453,71,41,1,11,3,1,2
-"Edison, District 3",3133,1469,74,37,2,10,1,1,2
-"Edison, District 4",3037,1419,72,38,0,10,1,1,2
-"Edison, District 5",3138,1425,72,42,0,10,1,1,2
-"Edison, District 6",3175,1371,71,40,1,10,1,1,2
-"Edison, District 7",2990,1365,70,40,0,11,1,1,2
-"Edison, District 8",3032,1412,73,42,0,10,1,1,2
-"Edison, District 9",2992,1395,68,38,0,10,1,1,2
-"Edison, District 10",3044,1473,73,39,0,10,2,1,2
-"Edison, District 11",3119,1461,78,43,0,11,1,1,3
-"Edison, District 12",3189,1465,72,38,1,10,1,2,2
-"Edison, District 13",3120,1379,70,41,1,10,1,1,3
-"Edison, District 14",3135,1526,79,42,0,11,2,1,2
-"Edison, District 15",3130,1475,73,42,0,12,1,1,2
-"Edison, District 16",3136,1483,76,37,1,11,2,1,2
-"Edison, District 17",3084,1443,73,41,1,11,1,1,2
-"Edison, District 18",3033,1393,70,39,0,10,1,1,2
-"Edison, District 19",3081,1429,71,39,0,11,1,1,2
-"Edison, District 20",3058,1376,73,39,0,10,1,1,2
-"Edison, District 21",3078,1447,73,38,0,10,1,1,2
-"Edison, District 22",3028,1433,68,39,0,10,1,1,2
-"Edison, District 23",3094,1469,72,43,2,10,1,1,2
-"Edison, District 24",3074,1416,75,41,1,10,1,1,2
-"Edison, District 25",3064,1394,74,38,0,10,1,1,2
-"Edison, District 26",3067,1444,74,40,1,11,1,2,2
-"Edison, District 27",3099,1608,81,37,1,10,1,2,2
-"Edison, District 28",3047,1315,68,38,0,10,1,1,2
-"Edison, District 29",3144,1463,69,37,1,11,1,2,3
-"Edison, District 30",3218,1518,73,44,0,11,2,2,2
-"Edison, District 31",3099,1444,75,47,0,11,1,1,2
-"Edison, District 32",3093,1363,70,42,0,10,1,1,2
-"Edison, District 33",3080,1410,81,37,1,10,1,1,2
-"Edison, District 34",3010,1400,73,36,0,10,1,1,2
-"Edison, District 35",3114,1426,74,40,0,10,1,1,2
-"Edison, District 36",3102,1382,78,36,0,10,1,1,2
-"Edison, District 37",3100,1498,75,40,0,10,1,1,2
-"Edison, District 38",3132,1404,75,37,0,11,1,1,2
-"Edison, District 39",3290,1349,73,44,0,11,1,1,2
-"Edison, District 40",3091,1428,71,37,0,11,1,1,2
-"Edison, District 41",3060,1378,76,42,0,10,1,1,2
-"Edison, District 42",3095,1349,68,41,1,10,1,1,2
-"Edison, District 43",3435,1410,67,46,1,10,1,1,2
-"Edison, District 44",3112,1456,71,43,0,10,2,1,2
-"Edison, District 45",3090,1422,71,41,0,10,1,1,2
-"Edison, District 46",3030,1417,77,38,1,11,1,1,2
-"Edison, District 47",3050,1410,75,38,2,10,1,1,2
-"Edison, District 48",3000,1384,69,36,0,10,3,1,2
-"Edison, District 49",3057,1484,78,38,0,12,2,3,2
-"Edison, District 50",3112,1412,72,37,0,12,1,1,2
-"Edison, District 51",3037,1388,68,40,2,10,1,1,2
-"Edison, District 52",3055,1437,71,41,0,10,1,1,2
-"Edison, District 53",3118,1440,77,39,0,11,1,1,2
-"Edison, District 54",3091,1403,70,39,0,10,1,1,2
-"Edison, District 55",3022,1399,68,37,0,10,1,1,2
-"Edison, District 56",3039,1400,75,37,1,10,1,1,2
-"Edison, District 57",3093,1431,69,39,0,11,1,2,2
-"Edison, District 58",3222,1341,68,40,0,10,1,1,2
-"Edison, District 59",3036,1395,72,37,1,13,1,1,2
-"Edison, District 60",3048,1416,76,37,0,11,1,1,2
-"Edison, District 61",3160,1460,74,40,0,10,2,1,2
-"Edison, District 62",3063,1428,74,37,0,11,1,1,2
-"Edison, District 63",3346,1407,75,48,2,11,3,1,3
-"Edison, District 64",3283,1460,74,45,0,10,2,2,2
-"Edison, District 65",3207,1452,74,43,0,10,1,1,2
-"Edison, District 66",3206,1464,72,38,0,10,1,1,2
-"Edison, District 67",3154,1506,74,42,1,11,1,1,2
-"Edison, District 68",3184,1528,74,43,0,10,1,1,2
-"Edison, District 69",3103,1391,68,40,0,10,1,1,2
-"Edison, District 70",3320,1456,72,38,0,11,1,1,2
-"Edison, District 71",3179,1411,69,41,1,10,2,1,2
-"Edison, District 72",3395,1505,71,40,1,10,1,1,2
-"Edison, District 73",3167,1492,73,37,1,10,1,3,2
-"Edison, District 74",3108,1430,70,39,0,10,1,1,2
-"Edison, District 75",3178,1347,68,39,0,11,1,1,2
-"Edison, District 76",3217,1478,69,38,0,13,1,1,2
-"Edison, District 77",3336,1429,71,39,0,10,3,1,2
-"Edison, District 78",3226,1350,66,37,1,10,1,1,2
-"Helmetta, District 1",414,608,24,9,0,0,0,0,0
-"Highland Park, District 1",1033,241,26,27,1,2,0,1,0
-"Highland Park, District 2",986,162,12,30,0,2,0,1,0
-"Highland Park, District 3",958,167,20,28,0,2,0,2,0
-"Highland Park, District 4",961,147,16,25,0,1,0,1,0
-"Highland Park, District 5",1019,224,27,24,0,1,0,2,0
-"Highland Park, District 6",1021,163,18,29,0,2,0,1,0
-"Highland Park, District 7",1044,159,17,30,0,1,0,1,0
-"Highland Park, District 8",1007,147,20,30,0,1,1,1,0
-"Highland Park, District 9",937,197,17,24,1,1,0,1,0
-"Highland Park, District 10",938,257,22,26,0,1,0,1,2
-"Highland Park, District 11",976,254,23,28,0,1,0,1,0
-"Highland Park, District 12",907,170,17,23,0,2,0,1,0
-"Highland Park, District 13",968,171,19,24,0,2,1,1,1
-"Jamesburg, District 1",317,374,16,9,0,1,0,0,0
-"Jamesburg, District 2",227,264,15,10,0,0,0,0,0
-"Jamesburg, District 3",259,269,18,9,0,1,0,0,0
-"Jamesburg, District 4",341,393,21,8,0,0,1,0,0
-"Metuchen, District 1",1016,505,38,19,1,3,0,2,0
-"Metuchen, District 2",1077,482,54,13,1,4,0,2,0
-"Metuchen, District 3",1010,441,37,16,3,3,1,2,0
-"Metuchen, District 4",987,423,35,14,2,4,0,2,0
-"Metuchen, District 5",998,477,32,12,2,4,0,3,0
-"Metuchen, District 6",956,443,30,13,1,3,0,2,0
-"Metuchen, District 7",938,444,36,13,2,4,0,2,0
-"Metuchen, District 8",949,422,41,13,1,3,0,4,0
-"Metuchen, District 9",909,406,35,15,2,3,0,3,0
-"Metuchen, District 10",1097,516,46,15,3,3,0,2,0
-"Metuchen, District 11",1250,540,45,22,1,3,0,2,0
-"Metuchen, District 12",946,459,32,13,1,5,0,3,1
-"Metuchen, District 13",888,417,35,11,1,4,0,3,0
-"Middlesex, District 1",465,444,19,9,3,2,0,0,0
-"Middlesex, District 2",560,610,26,18,0,1,1,0,0
-"Middlesex, District 3",537,440,17,16,0,1,0,0,0
-"Middlesex, District 4",516,605,23,11,0,3,0,0,0
-"Middlesex, District 5",492,609,29,9,4,4,0,0,0
-"Middlesex, District 6",382,462,22,13,1,1,0,0,1
-"Middlesex, District 7",516,611,31,16,1,3,0,1,0
-"Middlesex, District 8",505,576,27,8,1,2,0,0,0
-"Middlesex, District 9",535,563,22,12,0,1,0,0,0
-"Middlesex, District 10",627,524,31,12,2,2,1,0,2
-"Milltown, District 1",346,367,14,8,1,1,0,0,0
-"Milltown, District 2",382,471,18,14,2,1,0,0,0
-"Milltown, District 3",359,345,15,4,1,0,0,0,0
-"Milltown, District 4",319,330,22,8,1,0,0,0,1
-"Milltown, District 5",399,381,14,7,2,0,1,0,0
-"Milltown, District 6",293,319,17,7,2,0,0,0,0
-"Milltown, District 7",380,477,22,10,2,1,0,1,0
-"Milltown, District 8",350,439,21,10,2,0,1,0,0
-"Milltown, District 9",309,335,18,3,2,0,0,0,2
-"Monroe, Ward 1, District 1",1638,1105,38,15,2,5,1,1,1
-"Monroe, Ward 1, District 2",1551,1164,40,14,2,4,1,1,1
-"Monroe, Ward 1, District 3",1539,1113,39,12,2,4,1,1,1
-"Monroe, Ward 1, District 4",1552,1170,40,14,1,4,2,1,1
-"Monroe, Ward 1, District 5",1553,1129,37,12,1,4,1,1,1
-"Monroe, Ward 1, District 6",1501,1064,41,12,1,4,1,1,1
-"Monroe, Ward 1, District 7",1539,1121,37,14,2,5,1,1,1
-"Monroe, Ward 1, District 8",1500,1048,37,12,1,4,2,1,1
-"Monroe, Ward 1, District 9",1579,1101,38,12,1,5,1,1,1
-"Monroe, Ward 1, District 10",1582,1118,36,14,1,4,1,1,1
-"Monroe, Ward 1, District 11",1479,1138,42,16,2,4,1,1,1
-"Monroe, Ward 1, District 12",1717,1159,46,15,1,4,2,1,1
-"Monroe, Ward 1, District 13",1715,1197,44,12,1,4,1,1,1
-"Monroe, Ward 1, District 14",1968,1217,44,18,1,4,1,1,1
-"Monroe, Ward 1, District 15",1602,1095,42,18,1,4,1,1,2
-"Monroe, Ward 1, District 16",1550,1160,36,11,1,4,1,1,1
-"Monroe, Ward 1, District 17",1714,1148,42,12,1,5,2,1,1
-"Monroe, Ward 2, District 1",2673,2055,73,32,2,5,2,1,1
-"Monroe, Ward 2, District 2",2543,1808,68,28,2,6,3,1,1
-"Monroe, Ward 2, District 3",2536,1626,57,21,3,4,2,1,1
-"Monroe, Ward 2, District 4",2494,1904,67,22,4,4,2,2,1
-"Monroe, Ward 2, District 5",2466,1593,59,21,3,4,2,1,1
-"Monroe, Ward 2, District 6",2494,1612,58,23,2,4,2,1,1
-"Monroe, Ward 2, District 7",2560,1612,59,23,2,4,2,1,1
-"Monroe, Ward 2, District 8",2442,1576,59,20,2,4,2,1,1
-"Monroe, Ward 2, District 9",2542,1628,64,23,2,4,2,1,1
-"Monroe, Ward 2, District 10",2505,1688,58,22,3,4,2,1,1
-"Monroe, Ward 2, District 11",2446,1609,59,21,2,4,2,1,1
-"Monroe, Ward 2, District 12",2525,1592,62,20,2,4,2,1,1
-"Monroe, Ward 3, District 1",1530,1235,41,20,1,5,2,1,1
-"Monroe, Ward 3, District 2",1520,1161,46,12,1,4,2,1,1
-"Monroe, Ward 3, District 3",1520,1188,45,16,2,5,1,1,1
-"Monroe, Ward 3, District 4",1558,1265,42,16,2,4,1,1,1
-"Monroe, Ward 3, District 5",1667,1300,52,17,1,5,2,2,1
-"Monroe, Ward 3, District 6",1523,1214,42,12,1,4,1,1,1
-"Monroe, Ward 3, District 7",1586,1353,43,12,1,4,1,1,1
-"Monroe, Ward 3, District 8",1577,1259,47,17,1,5,1,2,1
-"Monroe, Ward 3, District 9",1625,1433,55,17,2,5,2,1,2
-"Monroe, Ward 3, District 10",1780,1302,40,13,1,4,1,1,1
-"Monroe, Ward 3, District 11",1600,1145,39,11,1,5,1,1,1
-"New Brunswick, Ward 1, District 1",963,155,23,17,3,3,2,3,0
-"New Brunswick, Ward 1, District 2",887,194,23,17,2,3,3,1,0
-"New Brunswick, Ward 1, District 3",926,155,21,18,3,3,3,2,0
-"New Brunswick, Ward 1, District 4",931,209,31,22,3,3,2,1,0
-"New Brunswick, Ward 1, District 5",914,301,30,14,2,5,2,1,0
-"New Brunswick, Ward 1, District 6",985,179,27,24,3,3,2,1,0
-"New Brunswick, Ward 2, District 1",1146,159,31,24,3,3,3,1,0
-"New Brunswick, Ward 2, District 2",855,134,22,18,3,3,2,1,0
-"New Brunswick, Ward 2, District 3",911,150,21,21,4,3,2,1,0
-"New Brunswick, Ward 2, District 4",874,142,29,20,3,3,2,1,0
-"New Brunswick, Ward 2, District 5",884,158,21,15,2,3,3,1,0
-"New Brunswick, Ward 2, District 6",829,160,21,15,3,3,3,1,0
-"New Brunswick, Ward 2, District 7",1244,177,26,19,2,3,3,1,0
-"New Brunswick, Ward 4, District 1",912,152,24,21,5,4,3,1,0
-"New Brunswick, Ward 4, District 2",1115,146,21,16,4,4,4,1,1
-"New Brunswick, Ward 4, District 3",858,141,21,16,2,3,2,1,0
-"New Brunswick, Ward 4, District 4",926,179,20,19,2,4,2,1,0
-"New Brunswick, Ward 4, District 5",920,149,19,15,3,3,2,1,1
-"New Brunswick, Ward 5, District 1",1009,193,36,19,2,3,2,1,0
-"New Brunswick, Ward 5, District 2",772,135,21,17,4,3,2,1,0
-"New Brunswick, Ward 5, District 3",865,170,23,28,2,4,3,1,1
-"New Brunswick, Ward 5, District 4",829,161,23,17,3,3,2,1,0
-"New Brunswick, Ward 6, District 1",984,189,30,20,2,3,2,2,0
-"New Brunswick, Ward 6, District 2",751,166,22,19,2,3,2,1,0
-"New Brunswick, Ward 6, District 3",911,201,33,23,2,3,2,1,0
-"New Brunswick, Ward 6, District 4",873,205,26,21,2,4,2,1,0
-"New Brunswick, Ward 6, District 5",760,165,24,16,2,4,2,1,0
-"New Brunswick, Ward 6, District 6",919,178,22,19,2,3,2,2,0
-"North Brunswick, District 1",1390,631,37,19,4,1,1,1,0
-"North Brunswick, District 2",1479,701,44,11,3,2,1,1,0
-"North Brunswick, District 3",1405,604,36,13,4,1,1,3,0
-"North Brunswick, District 4",1599,644,44,15,4,1,1,2,0
-"North Brunswick, District 5",1516,691,43,17,4,3,1,1,0
-"North Brunswick, District 6",1463,595,43,17,2,1,1,1,0
-"North Brunswick, District 7",1411,719,38,16,2,1,1,2,0
-"North Brunswick, District 8",1320,580,38,13,2,2,1,1,0
-"North Brunswick, District 9",1481,695,44,14,4,1,1,1,0
-"North Brunswick, District 10",1307,608,36,10,2,1,1,2,0
-"North Brunswick, District 11",1574,853,42,16,4,1,2,2,0
-"North Brunswick, District 12",1392,563,39,16,2,2,1,1,0
-"North Brunswick, District 13",1354,657,36,14,2,2,1,1,0
-"North Brunswick, District 14",1293,566,42,11,3,2,1,1,1
-"North Brunswick, District 15",1353,517,34,14,3,1,1,1,0
-"North Brunswick, District 16",1400,591,44,20,2,1,1,1,0
-"North Brunswick, District 17",1470,595,42,19,2,3,1,1,0
-"North Brunswick, District 18",1337,629,39,14,2,1,1,1,0
-"North Brunswick, District 19",1663,647,42,16,2,1,1,2,0
-"North Brunswick, District 20",1694,698,42,16,2,1,1,1,0
-"North Brunswick, District 21",1888,666,39,15,2,1,4,1,0
-"North Brunswick, District 22",1491,606,38,16,3,3,1,1,0
-"North Brunswick, District 23",1466,625,42,13,4,1,1,1,0
-"North Brunswick, District 24",1458,574,43,13,2,2,2,1,0
-"North Brunswick, District 25",1837,784,50,16,6,2,1,1,0
-"North Brunswick, District 26",1461,574,43,13,2,1,2,1,0
-"North Brunswick, District 27",1858,612,40,29,2,1,1,1,0
-"Old Bridge, Ward 1, District 1",1499,1468,49,34,2,3,1,1,1
-"Old Bridge, Ward 1, District 2",1492,1467,47,34,0,5,2,1,2
-"Old Bridge, Ward 1, District 3",1515,1474,53,36,0,3,1,2,1
-"Old Bridge, Ward 1, District 4",1495,1484,49,35,1,3,2,1,1
-"Old Bridge, Ward 1, District 5",1843,1697,55,45,0,5,1,2,2
-"Old Bridge, Ward 1, District 6",1469,1443,42,32,0,3,1,2,1
-"Old Bridge, Ward 1, District 7",1432,1419,43,32,0,3,1,2,1
-"Old Bridge, Ward 1, District 8",1725,1708,58,38,0,3,3,1,1
-"Old Bridge, Ward 1, District 9",1491,1456,51,33,2,3,1,2,1
-"Old Bridge, Ward 1, District 10",1430,1365,43,31,0,3,1,1,1
-"Old Bridge, Ward 2, District 1",1423,1358,45,31,0,3,1,1,1
-"Old Bridge, Ward 2, District 2",1778,1635,55,33,0,4,3,1,1
-"Old Bridge, Ward 2, District 3",1672,1629,52,32,0,9,1,1,1
-"Old Bridge, Ward 2, District 4",1768,1501,47,34,1,3,1,1,1
-"Old Bridge, Ward 2, District 5",1663,1705,50,35,0,4,1,1,1
-"Old Bridge, Ward 2, District 6",1374,1294,43,30,0,3,1,1,1
-"Old Bridge, Ward 2, District 7",1561,1457,47,31,0,3,1,1,1
-"Old Bridge, Ward 3, District 1",1755,1621,59,41,0,3,1,1,1
-"Old Bridge, Ward 3, District 2",1765,1684,61,55,2,4,1,1,1
-"Old Bridge, Ward 3, District 3",2003,1448,50,47,3,3,2,1,1
-"Old Bridge, Ward 3, District 4",1915,1507,49,41,1,4,2,1,1
-"Old Bridge, Ward 3, District 5",1799,1585,54,47,1,7,1,2,1
-"Old Bridge, Ward 3, District 6",1691,1601,54,42,1,3,2,1,1
-"Old Bridge, Ward 3, District 7",1641,1517,51,44,0,3,1,1,1
-"Old Bridge, Ward 4, District 1",1614,1511,47,39,2,3,2,1,1
-"Old Bridge, Ward 4, District 2",1551,1409,49,33,1,4,1,1,1
-"Old Bridge, Ward 4, District 3",1659,1647,49,35,1,3,1,1,1
-"Old Bridge, Ward 4, District 4",1480,1405,46,34,2,3,1,2,1
-"Old Bridge, Ward 4, District 5",1523,1490,47,34,0,3,3,2,1
-"Old Bridge, Ward 4, District 6",1624,1557,48,37,1,4,1,1,1
-"Old Bridge, Ward 4, District 7",1500,1460,48,34,0,3,1,1,1
-"Old Bridge, Ward 4, District 8",1618,1442,49,31,3,3,1,1,1
-"Old Bridge, Ward 4, District 9",1417,1358,43,31,0,3,1,1,1
-"Old Bridge, Ward 5, District 1",1499,1487,45,32,0,3,1,1,1
-"Old Bridge, Ward 5, District 2",1473,1521,51,33,0,4,1,1,1
-"Old Bridge, Ward 5, District 3",1478,1467,52,35,0,4,1,1,2
-"Old Bridge, Ward 5, District 4",1491,1515,47,37,1,3,2,1,1
-"Old Bridge, Ward 5, District 5",1500,1517,55,35,1,4,1,2,1
-"Old Bridge, Ward 5, District 6",1569,1603,51,33,0,4,1,3,1
-"Old Bridge, Ward 5, District 7",1622,1564,57,33,0,3,1,2,2
-"Old Bridge, Ward 5, District 8",1644,1565,50,35,0,3,1,1,1
-"Old Bridge, Ward 5, District 9",1512,1488,50,36,0,3,1,1,1
-"Old Bridge, Ward 6, District 1",1596,1578,59,36,1,4,1,1,1
-"Old Bridge, Ward 6, District 2",1551,1587,50,33,1,3,1,1,1
-"Old Bridge, Ward 6, District 3",1426,1423,52,32,0,3,1,1,1
-"Old Bridge, Ward 6, District 4",1487,1499,50,39,2,4,1,1,1
-"Old Bridge, Ward 6, District 5",1583,1553,47,38,1,3,2,1,1
-"Old Bridge, Ward 6, District 6",1602,1563,48,38,1,3,1,2,1
-"Old Bridge, Ward 6, District 7",1557,1572,50,34,0,5,1,1,1
-"Old Bridge, Ward 6, District 8",1708,1601,55,39,2,3,1,1,1
-"Perth Amboy, Ward 1, District 1",1879,310,12,20,3,0,0,1,1
-"Perth Amboy, Ward 1, District 2",1993,299,7,19,4,1,0,1,2
-"Perth Amboy, Ward 1, District 3",2038,311,8,21,4,0,0,1,2
-"Perth Amboy, Ward 1, District 4",1896,292,8,20,3,0,0,1,1
-"Perth Amboy, Ward 1, District 5",1951,297,6,21,3,0,1,1,2
-"Perth Amboy, Ward 2, District 1",2149,339,12,27,4,0,1,1,1
-"Perth Amboy, Ward 2, District 2",2079,343,12,24,3,0,0,1,1
-"Perth Amboy, Ward 3, District 1",1909,288,5,21,4,0,0,1,2
-"Perth Amboy, Ward 3, District 2",1935,297,6,19,2,0,0,1,1
-"Perth Amboy, Ward 4, District 1",1885,289,5,19,3,0,0,1,1
-"Perth Amboy, Ward 4, District 2",1988,292,9,19,3,0,1,1,1
-"Perth Amboy, Ward 4, District 3",1950,297,7,19,3,1,0,1,1
-"Perth Amboy, Ward 4, District 4",1923,290,9,18,4,1,0,1,1
-"Perth Amboy, Ward 4, District 5",2043,308,8,20,3,0,0,2,1
-"Perth Amboy, Ward 4, District 6",1985,341,8,19,3,0,0,1,1
-"Perth Amboy, Ward 5, District 1",1976,284,6,19,3,0,0,1,2
-"Perth Amboy, Ward 5, District 2",2090,315,6,22,2,0,0,1,1
-"Perth Amboy, Ward 5, District 3",2276,310,11,19,2,0,0,1,1
-"Perth Amboy, Ward 6, District 1",1906,276,10,17,6,0,0,1,1
-"Perth Amboy, Ward 6, District 2",1962,297,7,19,4,0,0,1,1
-"Perth Amboy, Ward 6, District 3",2040,338,6,19,2,0,0,1,1
-"Perth Amboy, Ward 6, District 4",2101,356,6,21,2,0,1,1,1
-"Perth Amboy, Ward 6, District 5",2004,364,9,20,2,0,2,2,1
-"Perth Amboy, Ward 6, District 6",1972,319,6,21,2,0,0,2,1
-"Perth Amboy, Ward 6, District 7",1975,321,6,25,3,0,0,1,1
-"Perth Amboy, Ward 6, District 8",1955,276,6,18,3,0,0,1,1
-"Perth Amboy, Ward 6, District 9",2102,350,8,23,2,0,0,2,1
-"Perth Amboy, Ward 6, District 10",2034,320,7,18,3,0,0,1,1
-"Perth Amboy, Ward 6, District 11",2012,338,8,22,2,0,1,1,1
-"Perth Amboy, Ward 6, District 12",2077,353,7,22,4,0,0,1,1
-"Perth Amboy, Ward 6, District 13",2099,393,5,25,5,1,0,1,1
-"Perth Amboy, Ward 6, District 14",2020,311,8,24,2,0,0,1,2
-"Piscataway, Ward 1, District 1",2004,598,44,27,4,6,3,1,0
-"Piscataway, Ward 1, District 2",1769,629,42,29,6,7,4,1,0
-"Piscataway, Ward 1, District 3",1881,676,42,30,3,6,3,1,0
-"Piscataway, Ward 1, District 4",1791,681,47,28,3,7,3,1,0
-"Piscataway, Ward 1, District 5",1832,760,44,30,4,6,3,2,1
-"Piscataway, Ward 1, District 6",1731,735,47,26,4,6,3,1,0
-"Piscataway, Ward 1, District 7",2101,684,42,34,5,6,4,1,1
-"Piscataway, Ward 1, District 8",1785,743,44,26,4,6,3,1,0
-"Piscataway, Ward 1, District 9",1695,689,50,28,3,6,7,2,0
-"Piscataway, Ward 2, District 1",1739,697,43,28,5,6,3,1,0
-"Piscataway, Ward 2, District 2",1723,690,44,30,4,8,3,1,0
-"Piscataway, Ward 2, District 3",1950,724,43,29,3,7,3,1,0
-"Piscataway, Ward 2, District 4",1723,697,43,28,4,6,5,1,0
-"Piscataway, Ward 2, District 5",1749,641,39,28,4,7,3,1,0
-"Piscataway, Ward 2, District 6",1887,782,52,26,3,7,3,1,1
-"Piscataway, Ward 2, District 7",1952,759,43,28,3,6,3,1,0
-"Piscataway, Ward 2, District 8",1822,617,38,27,3,6,3,1,0
-"Piscataway, Ward 2, District 9",1775,664,40,32,3,6,3,1,0
-"Piscataway, Ward 2, District 10",2096,716,54,28,4,7,5,1,0
-"Piscataway, Ward 3, District 1",1776,783,49,34,5,6,3,1,0
-"Piscataway, Ward 3, District 2",1845,730,45,34,3,6,3,1,0
-"Piscataway, Ward 3, District 3",1753,723,43,32,5,6,4,2,0
-"Piscataway, Ward 3, District 4",1998,634,39,30,3,6,3,1,0
-"Piscataway, Ward 3, District 5",1741,637,44,27,4,11,3,1,0
-"Piscataway, Ward 3, District 6",1745,591,42,30,4,6,3,2,0
-"Piscataway, Ward 3, District 7",1815,672,43,30,4,7,5,1,0
-"Piscataway, Ward 3, District 8",1879,701,45,28,4,6,3,1,0
-"Piscataway, Ward 3, District 9",1704,614,46,29,3,6,3,2,0
-"Piscataway, Ward 3, District 10",1722,723,41,32,3,6,4,1,0
-"Piscataway, Ward 4, District 1",1657,666,41,25,4,6,3,1,0
-"Piscataway, Ward 4, District 2",1721,601,41,28,3,7,3,1,0
-"Piscataway, Ward 4, District 3",1669,614,42,27,3,7,4,1,0
-"Piscataway, Ward 4, District 4",1795,619,52,33,3,6,3,1,0
-"Piscataway, Ward 4, District 5",2019,656,48,37,6,7,3,1,0
-"Piscataway, Ward 4, District 6",1916,613,57,32,3,6,3,1,0
-"Piscataway, Ward 4, District 7",1877,667,42,28,5,7,5,1,0
-"Piscataway, Ward 4, District 8",1779,730,43,25,5,6,3,1,0
-"Piscataway, Ward 4, District 9",1706,615,38,27,4,6,3,1,1
-"Piscataway, Ward 4, District 10",1673,632,43,32,3,6,3,1,0
-"Plainsboro, District 1",1402,399,41,15,2,1,0,1,0
-"Plainsboro, District 2",1191,251,35,14,1,0,0,1,0
-"Plainsboro, District 3",1282,329,32,14,1,0,0,1,0
-"Plainsboro, District 4",1306,324,33,21,2,2,0,1,0
-"Plainsboro, District 5",1632,374,37,21,3,1,0,1,0
-"Plainsboro, District 6",1226,287,30,9,2,1,0,1,0
-"Plainsboro, District 7",1192,259,26,10,1,0,0,1,0
-"Plainsboro, District 8",1097,242,25,9,1,0,0,1,0
-"Plainsboro, District 9",1270,318,38,13,1,1,1,1,0
-"Plainsboro, District 10",1222,315,35,10,1,0,1,4,0
-"Plainsboro, District 11",1041,215,26,9,2,1,0,1,0
-"Plainsboro, District 12",1167,246,26,13,2,0,0,1,0
-"Sayreville, District 1",967,865,28,18,0,2,1,0,0
-"Sayreville, District 2",1126,1006,35,24,1,2,1,1,0
-"Sayreville, District 3",1211,1056,34,20,1,1,1,0,0
-"Sayreville, District 4",976,969,32,25,0,1,1,0,0
-"Sayreville, District 5",991,944,35,19,1,1,1,0,1
-"Sayreville, District 6",882,877,31,13,0,3,1,0,0
-"Sayreville, District 7",958,903,35,15,0,2,1,0,0
-"Sayreville, District 8",906,906,30,17,1,3,1,1,0
-"Sayreville, District 9",912,886,33,12,1,1,1,0,0
-"Sayreville, District 10",1115,929,35,16,0,2,1,0,1
-"Sayreville, District 11",1033,1019,41,22,1,3,2,0,0
-"Sayreville, District 12",1132,1025,39,24,0,1,1,1,1
-"Sayreville, District 13",964,979,37,21,0,1,2,0,1
-"Sayreville, District 14",959,906,35,16,0,1,2,1,0
-"Sayreville, District 15",973,952,31,20,1,1,1,0,0
-"Sayreville, District 16",973,957,33,19,3,1,1,1,0
-"Sayreville, District 17",893,854,35,15,0,2,2,0,0
-"Sayreville, District 18",977,991,35,14,3,2,1,0,0
-"Sayreville, District 19",906,862,28,13,0,2,1,2,0
-"Sayreville, District 20",1041,832,31,18,1,1,1,0,0
-"Sayreville, District 21",991,905,37,13,2,1,1,0,0
-"Sayreville, District 22",932,916,39,14,1,1,1,0,0
-"Sayreville, District 23",924,890,30,16,0,1,1,0,0
-"Sayreville, District 24",965,1010,33,14,1,1,1,0,0
-"Sayreville, District 25",951,977,35,16,0,1,1,0,0
-"Sayreville, District 26",1031,963,35,17,1,1,1,0,1
-"Sayreville, District 27",1126,965,35,31,1,3,1,0,1
-"Sayreville, District 28",1100,905,33,15,0,2,2,3,0
-"Sayreville, District 29",917,864,33,14,0,2,1,0,0
-"Sayreville, District 30",1220,1006,39,24,0,1,2,1,0
-"Sayreville, District 31",1224,921,37,16,0,2,1,0,0
-"Sayreville, District 32",1048,971,35,15,0,3,1,0,0
-"Sayreville, District 33",1384,823,33,14,0,2,1,1,0
-"Sayreville, District 34",1092,889,33,21,0,1,1,1,0
-"Sayreville, District 35",1030,896,32,19,0,2,1,0,1
-"South Amboy, Ward 1, District 1",154,198,5,2,1,0,0,0,0
-"South Amboy, Ward 1, District 2",190,251,8,3,0,0,0,1,0
-"South Amboy, Ward 1, District 3",212,299,8,6,1,0,1,0,0
-"South Amboy, Ward 2, District 1",168,177,12,4,0,0,0,0,0
-"South Amboy, Ward 2, District 2",155,164,6,5,1,0,2,0,0
-"South Amboy, Ward 2, District 3",202,195,5,5,1,0,0,0,0
-"South Amboy, Ward 3, District 1",161,184,13,4,0,1,2,0,0
-"South Amboy, Ward 3, District 2",354,423,13,9,0,0,1,0,0
-"South Amboy, Ward 3, District 3",252,343,25,6,2,0,1,0,0
-"South Brunswick, District 1",2257,1016,65,17,3,2,1,0,0
-"South Brunswick, District 2",2133,918,58,19,2,2,1,0,0
-"South Brunswick, District 3",2110,863,68,29,2,2,1,0,0
-"South Brunswick, District 4",2034,1032,55,20,2,2,1,0,0
-"South Brunswick, District 5",2096,927,57,26,2,2,1,0,0
-"South Brunswick, District 6",2007,928,55,19,2,4,3,0,0
-"South Brunswick, District 7",2072,849,54,23,2,2,1,0,0
-"South Brunswick, District 8",2066,921,60,23,3,2,1,0,0
-"South Brunswick, District 9",2035,889,59,21,3,5,1,0,0
-"South Brunswick, District 10",1980,872,55,18,3,2,1,1,0
-"South Brunswick, District 11",2046,906,56,26,2,2,2,0,0
-"South Brunswick, District 12",1979,863,56,20,3,2,2,0,0
-"South Brunswick, District 13",2165,858,57,24,4,2,2,1,1
-"South Brunswick, District 14",2116,837,58,22,2,3,1,0,0
-"South Brunswick, District 15",2284,939,62,28,3,3,1,0,1
-"South Brunswick, District 16",2364,922,62,22,3,2,1,0,0
-"South Brunswick, District 17",2179,832,53,29,3,5,2,0,0
-"South Brunswick, District 18",2195,854,53,19,2,2,1,1,1
-"South Brunswick, District 19",2122,818,53,19,3,4,1,0,1
-"South Brunswick, District 20",2055,832,54,21,2,4,1,0,0
-"South Brunswick, District 21",2099,905,58,22,3,2,1,0,0
-"South Brunswick, District 22",2204,900,56,20,2,2,1,1,0
-"South Brunswick, District 23",2174,829,52,20,4,2,2,0,0
-"South Brunswick, District 24",2037,883,65,23,2,4,2,1,0
-"South Brunswick, District 25",2168,836,60,18,3,3,1,0,0
-"South Brunswick, District 26",2325,967,58,21,2,2,2,0,0
-"South Brunswick, District 27",2224,878,60,22,4,4,1,0,0
-"South Brunswick, District 28",2313,913,54,25,3,2,1,0,0
-"South Brunswick, District 29",2212,850,58,18,2,3,1,0,0
-"South Brunswick, District 30",2143,838,56,22,4,2,1,1,0
-"South Plainfield, District 1",846,556,39,14,0,2,1,1,2
-"South Plainfield, District 2",764,690,36,20,3,3,0,1,0
-"South Plainfield, District 3",762,627,29,15,0,4,1,1,0
-"South Plainfield, District 4",921,822,34,18,0,2,0,1,0
-"South Plainfield, District 5",676,619,33,11,2,1,0,1,0
-"South Plainfield, District 6",768,664,33,17,1,1,0,1,0
-"South Plainfield, District 7",882,668,28,12,1,3,0,1,0
-"South Plainfield, District 8",802,659,38,10,1,1,1,1,2
-"South Plainfield, District 9",737,684,38,13,1,1,0,1,0
-"South Plainfield, District 10",1048,705,31,18,1,1,1,1,0
-"South Plainfield, District 11",717,628,34,15,0,1,0,1,0
-"South Plainfield, District 12",699,657,34,13,2,1,0,2,0
-"South Plainfield, District 13",896,681,38,13,2,2,0,1,0
-"South Plainfield, District 14",768,724,37,16,0,1,0,1,0
-"South Plainfield, District 15",954,566,34,21,1,1,0,1,0
-"South River, District 1",448,352,10,9,0,3,0,0,0
-"South River, District 2",402,371,12,10,0,3,0,0,0
-"South River, District 3",391,419,15,7,0,2,0,0,0
-"South River, District 4",386,396,11,8,0,4,0,0,0
-"South River, District 5",414,427,8,11,1,2,0,0,0
-"South River, District 6",434,412,16,13,1,3,0,0,1
-"South River, District 7",421,400,11,7,0,2,0,0,0
-"South River, District 8",402,415,13,9,1,3,0,0,0
-"South River, District 9",434,356,7,8,1,3,0,0,0
-"South River, District 10",612,495,27,14,2,3,0,0,0
-"South River, District 11",471,420,12,12,0,2,0,0,0
-"South River, District 12",465,388,9,6,1,2,0,1,0
-"South River, District 13",423,379,14,10,0,3,1,0,0
-"South River, District 14",403,402,12,12,0,4,0,0,0
-"Spotswood, District 1",474,675,31,6,1,1,0,1,0
-"Spotswood, District 2",323,497,31,6,1,0,0,0,1
-"Spotswood, District 3",288,431,21,4,2,0,0,0,0
-"Spotswood, District 4",328,418,25,5,2,0,1,0,0
-"Spotswood, District 5",395,533,27,10,1,1,0,0,1
-"Spotswood, District 6",321,397,20,8,3,0,0,1,0
-"Spotswood, District 7",300,507,27,4,1,0,0,0,1
-"Woodbridge, Ward 1, District 1",2037,1437,57,39,10,8,2,3,1
-"Woodbridge, Ward 1, District 2",2001,1544,65,31,10,8,1,2,2
-"Woodbridge, Ward 1, District 3",2034,1442,59,32,6,7,1,2,2
-"Woodbridge, Ward 1, District 4",2041,1544,68,33,8,7,1,3,2
-"Woodbridge, Ward 1, District 5",2032,1486,62,34,6,9,1,2,1
-"Woodbridge, Ward 1, District 6",1970,1419,60,31,6,7,1,2,2
-"Woodbridge, Ward 1, District 7",2165,1574,60,37,7,10,2,2,2
-"Woodbridge, Ward 1, District 8",1929,1353,54,30,6,8,1,3,2
-"Woodbridge, Ward 1, District 9",1996,1468,60,34,6,11,2,2,1
-"Woodbridge, Ward 1, District 10",2096,1519,64,32,6,7,1,4,3
-"Woodbridge, Ward 1, District 11",1985,1478,57,32,7,8,1,2,2
-"Woodbridge, Ward 1, District 12",2126,1385,62,30,6,7,1,2,1
-"Woodbridge, Ward 1, District 13",2120,1600,59,34,7,7,4,2,2
-"Woodbridge, Ward 1, District 14",2043,1420,56,35,8,8,1,2,1
-"Woodbridge, Ward 1, District 15",1982,1517,58,34,8,7,1,2,1
-"Woodbridge, Ward 2, District 1",1989,1333,54,32,6,7,1,2,2
-"Woodbridge, Ward 2, District 2",1995,1468,53,33,8,7,1,2,1
-"Woodbridge, Ward 2, District 3",2047,1475,54,35,6,8,1,2,1
-"Woodbridge, Ward 2, District 4",1983,1521,63,34,6,7,2,2,1
-"Woodbridge, Ward 2, District 5",1977,1442,59,34,6,7,1,2,1
-"Woodbridge, Ward 2, District 6",1982,1436,61,30,7,7,1,2,1
-"Woodbridge, Ward 2, District 7",2055,1420,63,35,7,8,1,2,2
-"Woodbridge, Ward 2, District 8",2121,1510,64,32,10,8,2,3,1
-"Woodbridge, Ward 2, District 9",1999,1496,58,34,6,7,1,2,1
-"Woodbridge, Ward 2, District 10",1998,1433,57,37,7,7,1,2,1
-"Woodbridge, Ward 2, District 11",2013,1451,62,33,7,8,1,2,1
-"Woodbridge, Ward 2, District 12",2031,1492,62,37,8,8,1,3,1
-"Woodbridge, Ward 2, District 13",2171,1448,61,35,7,7,1,3,2
-"Woodbridge, Ward 2, District 14",2199,1351,55,30,8,7,1,3,1
-"Woodbridge, Ward 2, District 15",2050,1366,56,30,6,7,1,3,2
-"Woodbridge, Ward 3, District 1",1918,1453,54,35,7,7,1,2,1
-"Woodbridge, Ward 3, District 2",2089,1564,64,35,8,7,1,2,1
-"Woodbridge, Ward 3, District 3",1954,1503,57,30,6,7,1,2,1
-"Woodbridge, Ward 3, District 4",1930,1449,56,32,6,7,1,2,1
-"Woodbridge, Ward 3, District 5",1991,1458,58,32,6,7,1,2,1
-"Woodbridge, Ward 3, District 6",2043,1431,59,30,6,7,1,2,1
-"Woodbridge, Ward 3, District 7",2005,1481,57,33,7,7,1,2,1
-"Woodbridge, Ward 3, District 8",1994,1408,58,38,6,7,1,3,1
-"Woodbridge, Ward 3, District 9",2022,1456,54,38,7,10,3,2,1
-"Woodbridge, Ward 3, District 10",2229,1486,65,37,6,7,1,2,1
-"Woodbridge, Ward 3, District 11",2135,1325,54,34,6,7,1,2,1
-"Woodbridge, Ward 3, District 12",2166,1356,54,32,7,8,1,2,1
-"Woodbridge, Ward 3, District 13",2104,1501,60,35,7,7,1,2,1
-"Woodbridge, Ward 4, District 1",2758,1721,60,37,7,8,1,2,1
-"Woodbridge, Ward 4, District 2",2544,1732,68,43,6,9,2,2,1
-"Woodbridge, Ward 4, District 3",2479,1648,61,39,7,8,1,2,1
-"Woodbridge, Ward 4, District 4",2422,1654,63,40,6,8,1,2,1
-"Woodbridge, Ward 4, District 5",2514,1654,64,42,6,9,2,2,2
-"Woodbridge, Ward 4, District 6",2437,1669,61,38,6,8,1,2,1
-"Woodbridge, Ward 4, District 7",2621,1737,70,43,9,9,1,3,1
-"Woodbridge, Ward 4, District 8",2570,1693,63,40,6,8,2,2,1
-"Woodbridge, Ward 4, District 9",2627,1758,63,41,7,8,1,2,1
-"Woodbridge, Ward 4, District 10",2651,1720,74,39,7,8,1,2,1
-"Woodbridge, Ward 4, District 11",2549,1652,64,40,7,10,1,2,1
-"Woodbridge, Ward 4, District 12",2480,1629,60,36,8,8,1,2,2
-"Woodbridge, Ward 4, District 13",2449,1666,64,40,6,8,1,2,1
-"Woodbridge, Ward 4, District 14",2494,1695,60,41,7,8,1,2,1
-"Woodbridge, Ward 5, District 1",1924,1552,60,32,7,9,1,2,1
-"Woodbridge, Ward 5, District 2",1984,1403,59,29,7,7,1,2,1
-"Woodbridge, Ward 5, District 3",1942,1453,64,31,8,7,1,3,1
-"Woodbridge, Ward 5, District 4",1954,1486,58,31,6,8,2,2,1
-"Woodbridge, Ward 5, District 5",2059,1547,63,31,7,7,1,3,1
-"Woodbridge, Ward 5, District 6",2061,1529,60,42,6,7,1,6,1
-"Woodbridge, Ward 5, District 7",2055,1571,64,30,6,7,1,4,2
-"Woodbridge, Ward 5, District 8",2013,1535,69,31,7,8,1,2,1
-"Woodbridge, Ward 5, District 9",2145,1480,61,36,8,10,1,2,1
-"Woodbridge, Ward 5, District 10",2069,1568,60,32,7,7,1,2,1
-"Woodbridge, Ward 5, District 11",2003,1520,61,33,6,8,1,3,1
-"Woodbridge, Ward 5, District 12",2038,1561,66,38,7,7,2,2,1
-"Woodbridge, Ward 5, District 13",2003,1502,63,29,6,7,1,2,1
-"Woodbridge, Ward 5, District 14",1992,1475,59,33,7,7,1,4,2
-"Woodbridge, Ward 5, District 15",1963,1436,53,29,6,7,1,2,1
-"Woodbridge, Ward 5, District 16",2062,1554,55,39,6,7,1,3,1
-"Woodbridge, Ward 5, District 17",1969,1499,59,39,7,7,1,2,1
-"Woodbridge, Ward 5, District 18",1904,1450,56,29,6,7,1,2,1
-Total,1046230,578436,27880,15374,1321,2761,709,637,554
+"Carteret, District 1",1167,334,14,5,1,2,1,0,0
+"Carteret, District 2",383,113,6,5,0,0,0,0,0
+"Carteret, District 3",372,38,1,5,0,0,0,0,0
+"Carteret, District 4",314,45,1,1,0,0,0,0,2
+"Carteret, District 5",264,133,5,1,1,0,1,0,0
+"Carteret, District 6",266,88,3,4,0,1,1,0,0
+"Carteret, District 7",248,110,3,4,2,0,1,0,1
+"Carteret, District 8",373,94,2,3,3,3,0,0,0
+"Carteret, District 9",245,133,1,4,2,0,0,0,1
+"Carteret, District 10",225,150,5,0,0,0,0,0,0
+"Carteret, District 11",304,155,4,3,1,0,0,0,0
+"Carteret, District 12",262,189,7,4,0,0,0,0,0
+"Carteret, District 13",244,148,4,3,1,0,0,0,0
+"Carteret, District 14",188,120,1,2,0,1,0,0,0
+"Carteret, District 15",220,163,4,0,2,0,0,0,0
+"Carteret, District 16",216,120,2,1,0,1,0,0,0
+"Carteret, District 17",280,165,6,5,2,0,0,0,0
+"Carteret, District 18",212,134,2,2,0,1,0,0,0
+"Carteret, District 19",180,117,2,2,0,0,0,0,0
+"Cranbury, District 1",566,335,32,9,2,2,1,0,0
+"Cranbury, District 2",349,268,22,4,1,4,1,0,0
+"Cranbury, District 3",281,191,10,7,0,1,0,0,0
+"Dunellen, District 1",354,236,16,8,0,0,0,1,0
+"Dunellen, District 2",375,221,13,13,1,1,2,0,2
+"Dunellen, District 3",141,200,18,6,1,0,0,0,0
+"Dunellen, District 4",208,136,16,6,1,0,0,0,0
+"Dunellen, District 5",262,232,18,4,2,1,1,3,0
+"Dunellen, District 6",153,153,10,6,0,0,0,0,0
+"East Brunswick, District 1",2681,1501,99,46,1,6,2,0,3
+"East Brunswick, District 2",611,346,14,13,1,2,0,1,0
+"East Brunswick, District 3",237,241,7,6,0,2,0,1,0
+"East Brunswick, District 4",301,245,8,5,0,0,0,0,0
+"East Brunswick, District 5",142,102,3,6,0,3,0,0,1
+"East Brunswick, District 6",135,160,4,4,0,1,0,0,1
+"East Brunswick, District 7",237,238,8,3,2,1,1,0,0
+"East Brunswick, District 8",220,213,6,7,0,0,0,1,1
+"East Brunswick, District 9",199,210,12,3,3,2,0,0,0
+"East Brunswick, District 10",243,155,13,3,0,3,0,0,0
+"East Brunswick, District 11",125,138,5,3,0,1,1,0,0
+"East Brunswick, District 12",209,199,11,5,3,1,0,0,0
+"East Brunswick, District 13",275,208,10,5,1,1,0,0,0
+"East Brunswick, District 14",397,270,16,8,2,2,1,0,0
+"East Brunswick, District 15",176,123,2,2,0,0,0,0,0
+"East Brunswick, District 16",275,237,9,5,2,0,0,0,0
+"East Brunswick, District 17",259,183,5,4,0,0,0,1,0
+"East Brunswick, District 18",181,111,4,4,2,0,0,2,0
+"East Brunswick, District 19",179,131,14,6,0,1,0,2,0
+"East Brunswick, District 20",365,273,11,3,1,1,0,0,0
+"East Brunswick, District 21",244,202,4,8,0,0,0,0,0
+"East Brunswick, District 22",216,146,10,3,0,1,1,0,0
+"East Brunswick, District 23",318,218,17,4,1,2,0,0,0
+"East Brunswick, District 24",233,202,7,4,0,0,0,0,0
+"East Brunswick, District 25",230,161,3,5,0,1,0,0,0
+"East Brunswick, District 26",310,294,10,5,0,2,0,1,0
+"East Brunswick, District 27",205,274,10,6,1,0,0,1,0
+"East Brunswick, District 28",142,143,6,5,0,0,1,0,0
+"East Brunswick, District 29",274,204,16,3,1,0,0,1,0
+"East Brunswick, District 30",295,224,2,6,0,0,0,1,0
+"East Brunswick, District 31",325,282,9,11,0,0,0,0,0
+"East Brunswick, District 32",208,134,5,6,0,1,0,1,0
+"East Brunswick, District 33",242,132,11,5,1,1,0,0,1
+"East Brunswick, District 34",364,246,10,9,1,0,1,0,0
+"East Brunswick, District 35",141,122,6,7,1,0,0,0,0
+"East Brunswick, District 36",271,206,8,3,0,0,0,1,0
+"East Brunswick, District 37",341,225,14,6,1,1,0,0,0
+"East Brunswick, District 38",224,181,6,8,2,0,1,0,0
+"East Brunswick, District 39",217,180,7,9,0,1,0,0,0
+"East Brunswick, District 40",298,195,6,3,0,0,0,0,0
+"Edison, District 1",3766,1746,84,45,3,14,1,2,2
+"Edison, District 2",613,177,5,5,1,1,2,0,0
+"Edison, District 3",252,193,8,1,2,0,0,0,0
+"Edison, District 4",156,143,6,2,0,0,0,0,0
+"Edison, District 5",257,149,6,6,0,0,0,0,0
+"Edison, District 6",294,95,5,4,1,0,0,0,0
+"Edison, District 7",109,89,4,4,0,1,0,0,0
+"Edison, District 8",151,136,7,6,0,0,0,0,0
+"Edison, District 9",111,119,2,2,0,0,0,0,0
+"Edison, District 10",163,197,7,3,0,0,1,0,0
+"Edison, District 11",238,185,12,7,0,1,0,0,1
+"Edison, District 12",308,189,6,2,1,0,0,1,0
+"Edison, District 13",239,103,4,5,1,0,0,0,1
+"Edison, District 14",254,250,13,6,0,1,1,0,0
+"Edison, District 15",249,199,7,6,0,2,0,0,0
+"Edison, District 16",255,207,10,1,1,1,1,0,0
+"Edison, District 17",203,167,7,5,1,1,0,0,0
+"Edison, District 18",152,117,4,3,0,0,0,0,0
+"Edison, District 19",200,153,5,3,0,1,0,0,0
+"Edison, District 20",177,100,7,3,0,0,0,0,0
+"Edison, District 21",197,171,7,2,0,0,0,0,0
+"Edison, District 22",147,157,2,3,0,0,0,0,0
+"Edison, District 23",213,193,6,7,2,0,0,0,0
+"Edison, District 24",193,140,9,5,1,0,0,0,0
+"Edison, District 25",183,118,8,2,0,0,0,0,0
+"Edison, District 26",186,168,8,4,1,1,0,1,0
+"Edison, District 27",218,332,15,1,1,0,0,1,0
+"Edison, District 28",166,39,2,2,0,0,0,0,0
+"Edison, District 29",263,187,3,1,1,1,0,1,1
+"Edison, District 30",337,242,7,8,0,1,1,1,0
+"Edison, District 31",218,168,9,11,0,1,0,0,0
+"Edison, District 32",212,87,4,6,0,0,0,0,0
+"Edison, District 33",199,134,15,1,1,0,0,0,0
+"Edison, District 34",129,124,7,0,0,0,0,0,0
+"Edison, District 35",233,150,8,4,0,0,0,0,0
+"Edison, District 36",221,106,12,0,0,0,0,0,0
+"Edison, District 37",219,222,9,4,0,0,0,0,0
+"Edison, District 38",251,128,9,1,0,1,0,0,0
+"Edison, District 39",409,73,7,8,0,1,0,0,0
+"Edison, District 40",210,152,5,1,0,1,0,0,0
+"Edison, District 41",179,102,10,6,0,0,0,0,0
+"Edison, District 42",214,73,2,5,1,0,0,0,0
+"Edison, District 43",554,134,1,10,1,0,0,0,0
+"Edison, District 44",231,180,5,7,0,0,1,0,0
+"Edison, District 45",209,146,5,5,0,0,0,0,0
+"Edison, District 46",149,141,11,2,1,1,0,0,0
+"Edison, District 47",169,134,9,2,2,0,0,0,0
+"Edison, District 48",119,108,3,0,0,0,2,0,0
+"Edison, District 49",176,208,12,2,0,2,1,2,0
+"Edison, District 50",231,136,6,1,0,2,0,0,0
+"Edison, District 51",156,112,2,4,2,0,0,0,0
+"Edison, District 52",174,161,5,5,0,0,0,0,0
+"Edison, District 53",237,164,11,3,0,1,0,0,0
+"Edison, District 54",210,127,4,3,0,0,0,0,0
+"Edison, District 55",141,123,2,1,0,0,0,0,0
+"Edison, District 56",158,124,9,1,1,0,0,0,0
+"Edison, District 57",212,155,3,3,0,1,0,1,0
+"Edison, District 58",341,65,2,4,0,0,0,0,0
+"Edison, District 59",155,119,6,1,1,3,0,0,0
+"Edison, District 60",167,140,10,1,0,1,0,0,0
+"Edison, District 61",279,184,8,4,0,0,1,0,0
+"Edison, District 62",182,152,8,1,0,1,0,0,0
+"Edison, District 63",465,131,9,12,2,1,2,0,1
+"Edison, District 64",402,184,8,9,0,0,1,1,0
+"Edison, District 65",326,176,8,7,0,0,0,0,0
+"Edison, District 66",325,188,6,2,0,0,0,0,0
+"Edison, District 67",273,230,8,6,1,1,0,0,0
+"Edison, District 68",303,252,8,7,0,0,0,0,0
+"Edison, District 69",222,115,2,4,0,0,0,0,0
+"Edison, District 70",439,180,6,2,0,1,0,0,0
+"Edison, District 71",298,135,3,5,1,0,1,0,0
+"Edison, District 72",514,229,5,4,1,0,0,0,0
+"Edison, District 73",286,216,7,1,1,0,0,2,0
+"Edison, District 74",227,154,4,3,0,0,0,0,0
+"Edison, District 75",297,71,2,3,0,1,0,0,0
+"Edison, District 76",336,202,3,2,0,3,0,0,0
+"Edison, District 77",455,153,5,3,0,0,2,0,0
+"Edison, District 78",345,74,0,1,1,0,0,0,0
+"Helmetta, District 1",420,619,24,9,0,0,0,0,0
+"Highland Park, District 1",1174,308,32,33,1,2,0,1,0
+"Highland Park, District 2",308,58,1,13,0,1,0,0,0
+"Highland Park, District 3",280,63,9,11,0,1,0,1,0
+"Highland Park, District 4",283,43,5,8,0,0,0,0,0
+"Highland Park, District 5",341,120,16,7,0,0,0,1,0
+"Highland Park, District 6",343,59,7,12,0,1,0,0,0
+"Highland Park, District 7",366,55,6,13,0,0,0,0,0
+"Highland Park, District 8",329,43,9,13,0,0,1,0,0
+"Highland Park, District 9",259,93,6,7,1,0,0,0,0
+"Highland Park, District 10",260,153,11,9,0,0,0,0,2
+"Highland Park, District 11",298,150,12,11,0,0,0,0,0
+"Highland Park, District 12",229,66,6,6,0,1,0,0,0
+"Highland Park, District 13",290,67,8,7,0,1,1,0,1
+"Jamesburg, District 1",328,384,16,10,0,1,0,0,0
+"Jamesburg, District 2",145,168,7,7,0,0,0,0,0
+"Jamesburg, District 3",177,173,10,6,0,1,0,0,0
+"Jamesburg, District 4",259,297,13,5,0,0,1,0,0
+"Metuchen, District 1",1107,537,42,23,1,5,0,2,0
+"Metuchen, District 2",373,182,29,4,0,1,0,0,0
+"Metuchen, District 3",306,141,12,7,2,0,1,0,0
+"Metuchen, District 4",283,123,10,5,1,1,0,0,0
+"Metuchen, District 5",294,177,7,3,1,1,0,1,0
+"Metuchen, District 6",252,143,5,4,0,0,0,0,0
+"Metuchen, District 7",234,144,11,4,1,1,0,0,0
+"Metuchen, District 8",245,122,16,4,0,0,0,2,0
+"Metuchen, District 9",205,106,10,6,1,0,0,1,0
+"Metuchen, District 10",393,216,21,6,2,0,0,0,0
+"Metuchen, District 11",546,240,20,13,0,0,0,0,0
+"Metuchen, District 12",242,159,7,4,0,2,0,1,1
+"Metuchen, District 13",184,117,10,2,0,1,0,1,0
+"Middlesex, District 1",503,476,19,11,3,2,1,1,0
+"Middlesex, District 2",289,367,12,11,0,0,1,0,0
+"Middlesex, District 3",266,197,3,9,0,0,0,0,0
+"Middlesex, District 4",245,362,9,4,0,2,0,0,0
+"Middlesex, District 5",221,366,15,2,4,3,0,0,0
+"Middlesex, District 6",111,219,8,6,1,0,0,0,1
+"Middlesex, District 7",245,368,17,9,1,2,0,1,0
+"Middlesex, District 8",234,333,13,1,1,1,0,0,0
+"Middlesex, District 9",264,320,8,5,0,0,0,0,0
+"Middlesex, District 10",356,281,17,5,2,1,1,0,2
+"Milltown, District 1",373,387,14,8,1,1,0,0,0
+"Milltown, District 2",184,295,9,12,1,1,0,0,0
+"Milltown, District 3",161,169,6,2,0,0,0,0,0
+"Milltown, District 4",121,154,13,6,0,0,0,0,1
+"Milltown, District 5",201,205,5,5,1,0,1,0,0
+"Milltown, District 6",95,143,8,5,1,0,0,0,0
+"Milltown, District 7",182,301,13,8,1,1,0,1,0
+"Milltown, District 8",152,263,12,8,1,0,1,0,0
+"Milltown, District 9",111,159,9,1,1,0,0,0,2
+"Monroe, Ward 1, District 1",1768,1235,40,15,2,5,1,1,1
+"Monroe, Ward 1, District 2",190,220,4,3,1,0,0,0,0
+"Monroe, Ward 1, District 3",178,169,3,1,1,0,0,0,0
+"Monroe, Ward 1, District 4",191,226,4,3,0,0,1,0,0
+"Monroe, Ward 1, District 5",192,185,1,1,0,0,0,0,0
+"Monroe, Ward 1, District 6",140,120,5,1,0,0,0,0,0
+"Monroe, Ward 1, District 7",178,177,1,3,1,1,0,0,0
+"Monroe, Ward 1, District 8",139,104,1,1,0,0,1,0,0
+"Monroe, Ward 1, District 9",218,157,2,1,0,1,0,0,0
+"Monroe, Ward 1, District 10",221,174,0,3,0,0,0,0,0
+"Monroe, Ward 1, District 11",118,194,6,5,1,0,0,0,0
+"Monroe, Ward 1, District 12",356,215,10,4,0,0,1,0,0
+"Monroe, Ward 1, District 13",354,253,8,1,0,0,0,0,0
+"Monroe, Ward 1, District 14",607,273,8,7,0,0,0,0,0
+"Monroe, Ward 1, District 15",241,151,6,7,0,0,0,0,1
+"Monroe, Ward 1, District 16",189,216,0,0,0,0,0,0,0
+"Monroe, Ward 1, District 17",353,204,6,1,0,1,1,0,0
+"Monroe, Ward 2, District 1",1397,1175,39,22,1,1,1,0,0
+"Monroe, Ward 2, District 2",284,353,12,8,0,2,1,0,0
+"Monroe, Ward 2, District 3",277,171,1,1,1,0,0,0,0
+"Monroe, Ward 2, District 4",235,449,11,2,2,0,0,1,0
+"Monroe, Ward 2, District 5",207,138,3,1,1,0,0,0,0
+"Monroe, Ward 2, District 6",235,157,2,3,0,0,0,0,0
+"Monroe, Ward 2, District 7",301,157,3,3,0,0,0,0,0
+"Monroe, Ward 2, District 8",183,121,3,0,0,0,0,0,0
+"Monroe, Ward 2, District 9",283,173,8,3,0,0,0,0,0
+"Monroe, Ward 2, District 10",246,233,2,2,1,0,0,0,0
+"Monroe, Ward 2, District 11",187,154,3,1,0,0,0,0,0
+"Monroe, Ward 2, District 12",266,137,6,0,0,0,0,0,0
+"Monroe, Ward 2, District 13",319,351,13,4,0,0,0,0,0
+"Monroe, Ward 2, District 14",309,242,4,2,1,0,0,0,0
+"Monroe, Ward 2, District 15",270,201,3,1,0,1,0,0,0
+"Monroe, Ward 3, District 1",169,291,5,9,0,1,1,0,0
+"Monroe, Ward 3, District 2",159,217,10,1,0,0,1,0,0
+"Monroe, Ward 3, District 3",159,244,9,5,1,1,0,0,0
+"Monroe, Ward 3, District 4",197,321,6,5,1,0,0,0,0
+"Monroe, Ward 3, District 5",306,356,16,6,0,1,1,1,0
+"Monroe, Ward 3, District 6",162,270,6,1,0,0,0,0,0
+"Monroe, Ward 3, District 7",225,409,7,1,0,0,0,0,0
+"Monroe, Ward 3, District 8",216,315,11,6,0,1,0,1,0
+"Monroe, Ward 3, District 9",264,489,19,6,1,1,1,0,1
+"Monroe, Ward 3, District 10",419,358,4,2,0,0,0,0,0
+"Monroe, Ward 3, District 11",239,201,3,0,0,1,0,0,0
+"New Brunswick, Ward 1, District 1",1296,189,31,25,3,3,2,3,0
+"New Brunswick, Ward 1, District 2",246,71,4,4,0,0,1,0,0
+"New Brunswick, Ward 1, District 3",285,32,2,5,1,0,1,1,0
+"New Brunswick, Ward 1, District 4",290,86,12,9,1,0,0,0,0
+"New Brunswick, Ward 1, District 5",273,178,11,1,0,2,0,0,0
+"New Brunswick, Ward 1, District 6",344,56,8,11,1,0,0,0,0
+"New Brunswick, Ward 2, District 1",505,36,12,11,1,0,1,0,0
+"New Brunswick, Ward 2, District 2",214,11,3,5,1,0,0,0,0
+"New Brunswick, Ward 2, District 3",270,27,2,8,2,0,0,0,0
+"New Brunswick, Ward 2, District 4",233,19,10,7,1,0,0,0,0
+"New Brunswick, Ward 2, District 5",243,35,2,2,0,0,1,0,0
+"New Brunswick, Ward 2, District 6",188,37,2,2,1,0,1,0,0
+"New Brunswick, Ward 2, District 7",603,54,7,6,0,0,1,0,0
+"New Brunswick, Ward 4, District 1",271,29,5,8,3,1,1,0,0
+"New Brunswick, Ward 4, District 2",474,23,2,3,2,1,2,0,1
+"New Brunswick, Ward 4, District 3",217,18,2,3,0,0,0,0,0
+"New Brunswick, Ward 4, District 4",285,56,1,6,0,1,0,0,0
+"New Brunswick, Ward 4, District 5",279,26,0,2,1,0,0,0,1
+"New Brunswick, Ward 5, District 1",368,70,17,6,0,0,0,0,0
+"New Brunswick, Ward 5, District 2",131,12,2,4,2,0,0,0,0
+"New Brunswick, Ward 5, District 3",224,47,4,15,0,1,1,0,1
+"New Brunswick, Ward 5, District 4",188,38,4,4,1,0,0,0,0
+"New Brunswick, Ward 6, District 1",343,66,11,7,0,0,0,1,0
+"New Brunswick, Ward 6, District 2",110,43,3,6,0,0,0,0,0
+"New Brunswick, Ward 6, District 3",270,78,14,10,0,0,0,0,0
+"New Brunswick, Ward 6, District 4",232,82,7,8,0,1,0,0,0
+"New Brunswick, Ward 6, District 5",119,42,5,3,0,1,0,0,0
+"New Brunswick, Ward 6, District 6",278,55,3,6,0,0,0,1,0
+"North Brunswick, District 1",1585,696,43,22,4,1,1,1,0
+"North Brunswick, District 2",339,221,11,1,1,1,0,0,0
+"North Brunswick, District 3",265,124,3,3,2,0,0,2,0
+"North Brunswick, District 4",459,164,11,5,2,0,0,1,0
+"North Brunswick, District 5",376,211,10,7,2,2,0,0,0
+"North Brunswick, District 6",323,115,10,7,0,0,0,0,0
+"North Brunswick, District 7",271,239,5,6,0,0,0,1,0
+"North Brunswick, District 8",180,100,5,3,0,1,0,0,0
+"North Brunswick, District 9",341,215,11,4,2,0,0,0,0
+"North Brunswick, District 10",167,128,3,0,0,0,0,1,0
+"North Brunswick, District 11",434,373,9,6,2,0,1,1,0
+"North Brunswick, District 12",252,83,6,6,0,1,0,0,0
+"North Brunswick, District 13",214,177,3,4,0,1,0,0,0
+"North Brunswick, District 14",153,86,9,1,1,1,0,0,1
+"North Brunswick, District 15",213,37,1,4,1,0,0,0,0
+"North Brunswick, District 16",260,111,11,10,0,0,0,0,0
+"North Brunswick, District 17",330,115,9,9,0,2,0,0,0
+"North Brunswick, District 18",197,149,6,4,0,0,0,0,0
+"North Brunswick, District 19",523,167,9,6,0,0,0,1,0
+"North Brunswick, District 20",554,218,9,6,0,0,0,0,0
+"North Brunswick, District 21",748,186,6,5,0,0,3,0,0
+"North Brunswick, District 22",351,126,5,6,1,2,0,0,0
+"North Brunswick, District 23",326,145,9,3,2,0,0,0,0
+"North Brunswick, District 24",318,94,10,3,0,1,1,0,0
+"North Brunswick, District 25",697,304,17,6,4,1,0,0,0
+"North Brunswick, District 26",321,94,10,3,0,0,1,0,0
+"North Brunswick, District 27",718,132,7,19,0,0,0,0,0
+"Old Bridge, Ward 1, District 1",252,287,11,4,2,0,0,0,0
+"Old Bridge, Ward 1, District 2",769,785,24,17,0,4,2,0,1
+"Old Bridge, Ward 1, District 3",170,220,12,6,0,0,0,1,0
+"Old Bridge, Ward 1, District 4",150,230,8,5,1,0,1,0,0
+"Old Bridge, Ward 1, District 5",498,443,14,15,0,2,0,1,1
+"Old Bridge, Ward 1, District 6",124,189,1,2,0,0,0,1,0
+"Old Bridge, Ward 1, District 7",87,165,2,2,0,0,0,1,0
+"Old Bridge, Ward 1, District 8",380,454,17,8,0,0,2,0,0
+"Old Bridge, Ward 1, District 9",146,202,10,3,2,0,0,1,0
+"Old Bridge, Ward 1, District 10",909,908,32,20,0,1,0,1,1
+"Old Bridge, Ward 2, District 1",78,104,4,1,0,0,0,0,0
+"Old Bridge, Ward 2, District 2",433,381,14,3,0,1,2,0,0
+"Old Bridge, Ward 2, District 3",327,375,11,2,0,6,0,0,0
+"Old Bridge, Ward 2, District 4",423,247,6,4,1,0,0,0,0
+"Old Bridge, Ward 2, District 5",318,451,9,5,0,1,0,0,0
+"Old Bridge, Ward 2, District 6",29,40,2,0,0,0,0,0,0
+"Old Bridge, Ward 2, District 7",216,203,6,1,0,0,0,0,0
+"Old Bridge, Ward 2, District 8",195,270,10,4,0,0,1,0,0
+"Old Bridge, Ward 3, District 1",467,397,22,12,0,0,0,0,0
+"Old Bridge, Ward 3, District 2",252,316,15,17,2,1,0,0,0
+"Old Bridge, Ward 3, District 3",490,80,4,9,3,0,1,0,0
+"Old Bridge, Ward 3, District 4",402,139,3,3,1,1,1,0,0
+"Old Bridge, Ward 3, District 5",286,217,8,9,1,4,0,1,0
+"Old Bridge, Ward 3, District 6",178,233,8,4,1,0,1,0,0
+"Old Bridge, Ward 3, District 7",128,149,5,6,0,0,0,0,0
+"Old Bridge, Ward 4, District 1",269,257,6,9,2,0,1,0,0
+"Old Bridge, Ward 4, District 2",206,155,8,3,1,1,0,0,0
+"Old Bridge, Ward 4, District 3",314,393,8,5,1,0,0,0,0
+"Old Bridge, Ward 4, District 4",135,151,5,4,2,0,0,1,0
+"Old Bridge, Ward 4, District 5",178,236,6,4,0,0,2,1,0
+"Old Bridge, Ward 4, District 6",279,303,7,7,1,1,0,0,0
+"Old Bridge, Ward 4, District 7",155,206,7,4,0,0,0,0,0
+"Old Bridge, Ward 4, District 8",273,188,8,1,3,0,0,0,0
+"Old Bridge, Ward 4, District 9",72,104,2,1,0,0,0,0,0
+"Old Bridge, Ward 5, District 1",154,233,4,2,0,0,0,0,0
+"Old Bridge, Ward 5, District 2",128,267,10,3,0,1,0,0,0
+"Old Bridge, Ward 5, District 3",133,213,11,5,0,1,0,0,1
+"Old Bridge, Ward 5, District 4",146,261,6,7,1,0,1,0,0
+"Old Bridge, Ward 5, District 5",155,263,14,5,1,1,0,1,0
+"Old Bridge, Ward 5, District 6",224,349,10,3,0,1,0,2,0
+"Old Bridge, Ward 5, District 7",277,310,16,3,0,0,0,1,1
+"Old Bridge, Ward 5, District 8",299,311,9,5,0,0,0,0,0
+"Old Bridge, Ward 5, District 9",167,234,9,6,0,0,0,0,0
+"Old Bridge, Ward 5, District 10",287,278,6,7,0,1,0,0,0
+"Old Bridge, Ward 6, District 1",251,324,18,6,1,1,0,0,0
+"Old Bridge, Ward 6, District 2",206,333,9,3,1,0,0,0,0
+"Old Bridge, Ward 6, District 3",81,169,11,2,0,0,0,0,0
+"Old Bridge, Ward 6, District 4",142,245,9,9,2,1,0,0,0
+"Old Bridge, Ward 6, District 5",238,299,6,8,1,0,1,0,0
+"Old Bridge, Ward 6, District 6",257,309,7,8,1,0,0,1,0
+"Old Bridge, Ward 6, District 7",212,318,9,4,0,2,0,0,0
+"Old Bridge, Ward 6, District 8",363,347,14,9,2,0,0,0,0
+"Perth Amboy, Ward 1, District 1",2753,419,16,25,6,0,0,2,1
+"Perth Amboy, Ward 1, District 2",274,43,2,2,2,1,0,0,1
+"Perth Amboy, Ward 1, District 3",319,55,3,4,2,0,0,0,1
+"Perth Amboy, Ward 1, District 4",177,36,3,3,1,0,0,0,0
+"Perth Amboy, Ward 1, District 5",232,41,1,4,1,0,1,0,1
+"Perth Amboy, Ward 2, District 1",430,83,7,10,2,0,1,0,0
+"Perth Amboy, Ward 2, District 2",360,87,7,7,1,0,0,0,0
+"Perth Amboy, Ward 3, District 1",190,32,0,4,2,0,0,0,1
+"Perth Amboy, Ward 3, District 2",216,41,1,2,0,0,0,0,0
+"Perth Amboy, Ward 4, District 1",166,33,0,2,1,0,0,0,0
+"Perth Amboy, Ward 4, District 2",269,36,4,2,1,0,1,0,0
+"Perth Amboy, Ward 4, District 3",231,41,2,2,1,1,0,0,0
+"Perth Amboy, Ward 4, District 4",204,34,4,1,2,1,0,0,0
+"Perth Amboy, Ward 4, District 5",324,52,3,3,1,0,0,1,0
+"Perth Amboy, Ward 4, District 6",266,85,3,2,1,0,0,0,0
+"Perth Amboy, Ward 5, District 1",257,28,1,2,1,0,0,0,1
+"Perth Amboy, Ward 5, District 2",371,59,1,5,0,0,0,0,0
+"Perth Amboy, Ward 5, District 3",557,54,6,2,0,0,0,0,0
+"Perth Amboy, Ward 6, District 1",187,20,5,0,4,0,0,0,0
+"Perth Amboy, Ward 6, District 2",243,41,2,2,2,0,0,0,0
+"Perth Amboy, Ward 6, District 3",321,82,1,2,0,0,0,0,0
+"Perth Amboy, Ward 6, District 4",382,100,1,4,0,0,1,0,0
+"Perth Amboy, Ward 6, District 5",285,108,4,3,0,0,2,1,0
+"Perth Amboy, Ward 6, District 6",253,63,1,4,0,0,0,1,0
+"Perth Amboy, Ward 6, District 7",256,65,1,8,1,0,0,0,0
+"Perth Amboy, Ward 6, District 8",236,20,1,1,1,0,0,0,0
+"Perth Amboy, Ward 6, District 9",383,94,3,6,0,0,0,1,0
+"Perth Amboy, Ward 6, District 10",315,64,2,1,1,0,0,0,0
+"Perth Amboy, Ward 6, District 11",293,82,3,5,0,0,1,0,0
+"Perth Amboy, Ward 6, District 12",358,97,2,5,2,0,0,0,0
+"Perth Amboy, Ward 6, District 13",380,137,0,8,3,1,0,0,0
+"Perth Amboy, Ward 6, District 14",301,55,3,7,0,0,0,0,1
+"Piscataway, Ward 1, District 1",2358,668,54,31,4,7,5,2,0
+"Piscataway, Ward 1, District 2",314,76,6,6,3,1,1,0,0
+"Piscataway, Ward 1, District 3",426,123,6,7,0,0,0,0,0
+"Piscataway, Ward 1, District 4",336,128,11,5,0,1,0,0,0
+"Piscataway, Ward 1, District 5",377,207,8,7,1,0,0,1,1
+"Piscataway, Ward 1, District 6",276,182,11,3,1,0,0,0,0
+"Piscataway, Ward 1, District 7",646,131,6,11,2,0,1,0,1
+"Piscataway, Ward 1, District 8",330,190,8,3,1,0,0,0,0
+"Piscataway, Ward 1, District 9",240,136,14,5,0,0,4,1,0
+"Piscataway, Ward 2, District 1",284,144,7,5,2,0,0,0,0
+"Piscataway, Ward 2, District 2",268,137,8,7,1,2,0,0,0
+"Piscataway, Ward 2, District 3",495,171,7,6,0,1,0,0,0
+"Piscataway, Ward 2, District 4",268,144,7,5,1,0,2,0,0
+"Piscataway, Ward 2, District 5",294,88,3,5,1,1,0,0,0
+"Piscataway, Ward 2, District 6",432,229,16,3,0,1,0,0,1
+"Piscataway, Ward 2, District 7",497,206,7,5,0,0,0,0,0
+"Piscataway, Ward 2, District 8",367,64,2,4,0,0,0,0,0
+"Piscataway, Ward 2, District 9",320,111,4,9,0,0,0,0,0
+"Piscataway, Ward 2, District 10",641,163,18,5,1,1,2,0,0
+"Piscataway, Ward 3, District 1",321,230,13,11,2,0,0,0,0
+"Piscataway, Ward 3, District 2",390,177,9,11,0,0,0,0,0
+"Piscataway, Ward 3, District 3",298,170,7,9,2,0,1,1,0
+"Piscataway, Ward 3, District 4",543,81,3,7,0,0,0,0,0
+"Piscataway, Ward 3, District 5",286,84,8,4,1,5,0,0,0
+"Piscataway, Ward 3, District 6",290,38,6,7,1,0,0,1,0
+"Piscataway, Ward 3, District 7",360,119,7,7,1,1,2,0,0
+"Piscataway, Ward 3, District 8",424,148,9,5,1,0,0,0,0
+"Piscataway, Ward 3, District 9",249,61,10,6,0,0,0,1,0
+"Piscataway, Ward 3, District 10",267,170,5,9,0,0,1,0,0
+"Piscataway, Ward 4, District 1",202,113,5,2,1,0,0,0,0
+"Piscataway, Ward 4, District 2",266,48,5,5,0,1,0,0,0
+"Piscataway, Ward 4, District 3",214,61,6,4,0,1,1,0,0
+"Piscataway, Ward 4, District 4",340,66,16,10,0,0,0,0,0
+"Piscataway, Ward 4, District 5",564,103,12,14,3,1,0,0,0
+"Piscataway, Ward 4, District 6",461,60,21,9,0,0,0,0,0
+"Piscataway, Ward 4, District 7",422,114,6,5,2,1,2,0,0
+"Piscataway, Ward 4, District 8",324,177,7,2,2,0,0,0,0
+"Piscataway, Ward 4, District 9",251,62,2,4,1,0,0,0,1
+"Piscataway, Ward 4, District 10",218,79,7,9,0,0,0,0,0
+"Plainsboro, District 1",1585,440,45,19,2,1,0,1,0
+"Plainsboro, District 2",317,77,13,6,0,0,0,0,0
+"Plainsboro, District 3",408,155,10,6,0,0,0,0,0
+"Plainsboro, District 4",432,150,11,13,1,2,0,0,0
+"Plainsboro, District 5",758,200,15,13,2,1,0,0,0
+"Plainsboro, District 6",352,113,8,1,1,1,0,0,0
+"Plainsboro, District 7",318,85,4,2,0,0,0,0,0
+"Plainsboro, District 8",223,68,3,1,0,0,0,0,0
+"Plainsboro, District 9",396,144,16,5,0,1,1,0,0
+"Plainsboro, District 10",348,141,13,2,0,0,1,3,0
+"Plainsboro, District 11",167,41,4,1,1,1,0,0,0
+"Plainsboro, District 12",293,72,4,5,1,0,0,0,0
+"Plainsboro, District 13",363,114,14,3,0,1,0,0,0
+"Sayreville, District 1",1093,997,33,22,0,2,1,0,0
+"Sayreville, District 2",330,296,8,12,1,1,0,1,0
+"Sayreville, District 3",415,346,7,8,1,0,0,0,0
+"Sayreville, District 4",180,259,5,13,0,0,0,0,0
+"Sayreville, District 5",195,234,8,7,1,0,0,0,1
+"Sayreville, District 6",86,167,4,1,0,2,0,0,0
+"Sayreville, District 7",162,193,8,3,0,1,0,0,0
+"Sayreville, District 8",110,196,3,5,1,2,0,1,0
+"Sayreville, District 9",116,176,6,0,1,0,0,0,0
+"Sayreville, District 10",319,219,8,4,0,1,0,0,1
+"Sayreville, District 11",237,309,14,10,1,2,1,0,0
+"Sayreville, District 12",336,315,12,12,0,0,0,1,1
+"Sayreville, District 13",168,269,10,9,0,0,1,0,1
+"Sayreville, District 14",163,196,8,4,0,0,1,1,0
+"Sayreville, District 15",177,242,4,8,1,0,0,0,0
+"Sayreville, District 16",177,247,6,7,3,0,0,1,0
+"Sayreville, District 17",97,144,8,3,0,1,1,0,0
+"Sayreville, District 18",181,281,8,2,3,1,0,0,0
+"Sayreville, District 19",110,152,1,1,0,1,0,2,0
+"Sayreville, District 20",245,122,4,6,1,0,0,0,0
+"Sayreville, District 21",195,195,10,1,2,0,0,0,0
+"Sayreville, District 22",136,206,12,2,1,0,0,0,0
+"Sayreville, District 23",128,180,3,4,0,0,0,0,0
+"Sayreville, District 24",169,300,6,2,1,0,0,0,0
+"Sayreville, District 25",155,267,8,4,0,0,0,0,0
+"Sayreville, District 26",235,253,8,5,1,0,0,0,1
+"Sayreville, District 27",330,255,8,19,1,2,0,0,1
+"Sayreville, District 28",304,195,6,3,0,1,1,3,0
+"Sayreville, District 29",121,154,6,2,0,1,0,0,0
+"Sayreville, District 30",424,296,12,12,0,0,1,1,0
+"Sayreville, District 31",428,211,10,4,0,1,0,0,0
+"Sayreville, District 32",252,261,8,3,0,2,0,0,0
+"Sayreville, District 33",588,113,6,2,0,1,0,1,0
+"Sayreville, District 34",296,179,6,9,0,0,0,1,0
+"Sayreville, District 35",234,186,5,7,0,1,0,0,1
+"South Amboy, Ward 1, District 1",161,205,5,2,1,0,0,0,0
+"South Amboy, Ward 1, District 2",153,192,7,2,0,0,0,1,0
+"South Amboy, Ward 1, District 3",175,240,7,5,1,0,1,0,0
+"South Amboy, Ward 2, District 1",176,188,12,4,0,0,0,0,0
+"South Amboy, Ward 2, District 2",122,138,5,5,1,0,2,0,0
+"South Amboy, Ward 2, District 3",169,169,4,5,1,0,0,0,0
+"South Amboy, Ward 3, District 1",171,192,13,4,0,1,2,0,0
+"South Amboy, Ward 3, District 2",253,326,6,6,0,0,0,0,0
+"South Amboy, Ward 3, District 3",151,246,18,3,2,0,0,0,0
+"South Brunswick, District 1",2501,1096,73,22,3,2,1,0,0
+"South Brunswick, District 2",353,209,11,3,0,0,0,0,0
+"South Brunswick, District 3",339,157,21,13,0,0,0,0,0
+"South Brunswick, District 4",254,323,8,4,0,0,0,0,0
+"South Brunswick, District 5",316,218,10,10,0,0,0,0,0
+"South Brunswick, District 6",227,219,8,3,0,2,2,0,0
+"South Brunswick, District 7",292,140,7,7,0,0,0,0,0
+"South Brunswick, District 8",286,212,13,7,1,0,0,0,0
+"South Brunswick, District 9",255,180,12,5,1,3,0,0,0
+"South Brunswick, District 10",200,163,8,2,1,0,0,1,0
+"South Brunswick, District 11",266,197,9,10,0,0,1,0,0
+"South Brunswick, District 12",199,154,9,4,1,0,1,0,0
+"South Brunswick, District 13",385,149,10,8,2,0,1,1,1
+"South Brunswick, District 14",336,128,11,6,0,1,0,0,0
+"South Brunswick, District 15",504,230,15,12,1,1,0,0,1
+"South Brunswick, District 16",584,213,15,6,1,0,0,0,0
+"South Brunswick, District 17",399,123,6,13,1,3,1,0,0
+"South Brunswick, District 18",415,145,6,3,0,0,0,1,1
+"South Brunswick, District 19",342,109,6,3,1,2,0,0,1
+"South Brunswick, District 20",275,123,7,5,0,2,0,0,0
+"South Brunswick, District 21",319,196,11,6,1,0,0,0,0
+"South Brunswick, District 22",424,191,9,4,0,0,0,1,0
+"South Brunswick, District 23",394,120,5,4,2,0,1,0,0
+"South Brunswick, District 24",257,174,18,7,0,2,1,1,0
+"South Brunswick, District 25",388,127,13,2,1,1,0,0,0
+"South Brunswick, District 26",545,258,11,5,0,0,1,0,0
+"South Brunswick, District 27",444,169,13,6,2,2,0,0,0
+"South Brunswick, District 28",533,204,7,9,1,0,0,0,0
+"South Brunswick, District 29",432,141,11,2,0,1,0,0,0
+"South Brunswick, District 30",363,129,9,6,2,0,0,1,0
+"South Plainfield, District 1",922,602,44,15,1,2,1,1,2
+"South Plainfield, District 2",274,318,14,12,3,2,0,0,0
+"South Plainfield, District 3",272,255,7,7,0,3,1,0,0
+"South Plainfield, District 4",431,450,12,10,0,1,0,0,0
+"South Plainfield, District 5",186,247,11,3,2,0,0,0,0
+"South Plainfield, District 6",278,292,11,9,1,0,0,0,0
+"South Plainfield, District 7",392,296,6,4,1,2,0,0,0
+"South Plainfield, District 8",312,287,16,2,1,0,1,0,2
+"South Plainfield, District 9",247,312,16,5,1,0,0,0,0
+"South Plainfield, District 10",558,333,9,10,1,0,1,0,0
+"South Plainfield, District 11",227,256,12,7,0,0,0,0,0
+"South Plainfield, District 12",209,285,12,5,2,0,0,1,0
+"South Plainfield, District 13",406,309,16,5,2,1,0,0,0
+"South Plainfield, District 14",278,352,15,8,0,0,0,0,0
+"South Plainfield, District 15",464,194,12,13,1,0,0,0,0
+"South River, District 1",493,379,10,9,0,3,1,0,0
+"South River, District 2",132,144,6,4,0,1,0,0,0
+"South River, District 3",121,192,9,1,0,0,0,0,0
+"South River, District 4",116,169,5,2,0,2,0,0,0
+"South River, District 5",144,200,2,5,1,0,0,0,0
+"South River, District 6",164,185,10,7,1,1,0,0,1
+"South River, District 7",151,173,5,1,0,0,0,0,0
+"South River, District 8",132,188,7,3,1,1,0,0,0
+"South River, District 9",164,129,1,2,1,1,0,0,0
+"South River, District 10",342,268,21,8,2,1,0,0,0
+"South River, District 11",201,193,6,6,0,0,0,0,0
+"South River, District 12",195,161,3,0,1,0,0,1,0
+"South River, District 13",153,152,8,4,0,1,1,0,0
+"South River, District 14",133,175,6,6,0,2,0,0,0
+"Spotswood, District 1",489,694,34,7,1,2,0,1,0
+"Spotswood, District 2",155,314,18,4,0,0,0,0,1
+"Spotswood, District 3",120,248,8,2,1,0,0,0,0
+"Spotswood, District 4",160,235,12,3,1,0,1,0,0
+"Spotswood, District 5",227,350,14,8,0,1,0,0,1
+"Spotswood, District 6",153,214,7,6,2,0,0,1,0
+"Spotswood, District 7",132,324,14,2,0,0,0,0,1
+"Woodbridge, Ward 1, District 1",2354,1615,69,42,11,8,2,4,1
+"Woodbridge, Ward 1, District 2",213,269,13,3,4,1,0,0,1
+"Woodbridge, Ward 1, District 3",246,167,7,4,0,0,0,0,1
+"Woodbridge, Ward 1, District 4",253,269,16,5,2,0,0,1,1
+"Woodbridge, Ward 1, District 5",244,211,10,6,0,2,0,0,0
+"Woodbridge, Ward 1, District 6",182,144,8,3,0,0,0,0,1
+"Woodbridge, Ward 1, District 7",377,299,8,9,1,3,1,0,1
+"Woodbridge, Ward 1, District 8",141,78,2,2,0,1,0,1,1
+"Woodbridge, Ward 1, District 9",208,193,8,6,0,4,1,0,0
+"Woodbridge, Ward 1, District 10",308,244,12,4,0,0,0,2,2
+"Woodbridge, Ward 1, District 11",197,203,5,4,1,1,0,0,1
+"Woodbridge, Ward 1, District 12",338,110,10,2,0,0,0,0,0
+"Woodbridge, Ward 1, District 13",332,325,7,6,1,0,3,0,1
+"Woodbridge, Ward 1, District 14",255,145,4,7,2,1,0,0,0
+"Woodbridge, Ward 1, District 15",194,242,6,6,2,0,0,0,0
+"Woodbridge, Ward 2, District 1",201,58,2,4,0,0,0,0,1
+"Woodbridge, Ward 2, District 2",207,193,1,5,2,0,0,0,0
+"Woodbridge, Ward 2, District 3",259,200,2,7,0,1,0,0,0
+"Woodbridge, Ward 2, District 4",195,246,11,6,0,0,1,0,0
+"Woodbridge, Ward 2, District 5",189,167,7,6,0,0,0,0,0
+"Woodbridge, Ward 2, District 6",194,161,9,2,1,0,0,0,0
+"Woodbridge, Ward 2, District 7",267,145,11,7,1,1,0,0,1
+"Woodbridge, Ward 2, District 8",333,235,12,4,4,1,1,1,0
+"Woodbridge, Ward 2, District 9",211,221,6,6,0,0,0,0,0
+"Woodbridge, Ward 2, District 10",210,158,5,9,1,0,0,0,0
+"Woodbridge, Ward 2, District 11",225,176,10,5,1,1,0,0,0
+"Woodbridge, Ward 2, District 12",243,217,10,9,2,1,0,1,0
+"Woodbridge, Ward 2, District 13",383,173,9,7,1,0,0,1,1
+"Woodbridge, Ward 2, District 14",411,76,3,2,2,0,0,1,0
+"Woodbridge, Ward 2, District 15",262,91,4,2,0,0,0,1,1
+"Woodbridge, Ward 3, District 1",130,178,2,7,1,0,0,0,0
+"Woodbridge, Ward 3, District 2",301,289,12,7,2,0,0,0,0
+"Woodbridge, Ward 3, District 3",166,228,5,2,0,0,0,0,0
+"Woodbridge, Ward 3, District 4",142,174,4,4,0,0,0,0,0
+"Woodbridge, Ward 3, District 5",203,183,6,4,0,0,0,0,0
+"Woodbridge, Ward 3, District 6",255,156,7,2,0,0,0,0,0
+"Woodbridge, Ward 3, District 7",217,206,5,5,1,0,0,0,0
+"Woodbridge, Ward 3, District 8",206,133,6,10,0,0,0,1,0
+"Woodbridge, Ward 3, District 9",234,181,2,10,1,3,2,0,0
+"Woodbridge, Ward 3, District 10",441,211,13,9,0,0,0,0,0
+"Woodbridge, Ward 3, District 11",347,50,2,6,0,0,0,0,0
+"Woodbridge, Ward 3, District 12",378,81,2,4,1,1,0,0,0
+"Woodbridge, Ward 3, District 13",316,226,8,7,1,0,0,0,0
+"Woodbridge, Ward 4, District 1",1087,475,12,11,1,1,0,0,0
+"Woodbridge, Ward 4, District 2",289,207,9,7,0,1,1,0,0
+"Woodbridge, Ward 4, District 3",224,123,2,3,1,0,0,0,0
+"Woodbridge, Ward 4, District 4",167,129,4,4,0,0,0,0,0
+"Woodbridge, Ward 4, District 5",259,129,5,6,0,1,1,0,1
+"Woodbridge, Ward 4, District 6",182,144,2,2,0,0,0,0,0
+"Woodbridge, Ward 4, District 7",366,212,11,7,3,1,0,1,0
+"Woodbridge, Ward 4, District 8",315,168,4,4,0,0,1,0,0
+"Woodbridge, Ward 4, District 9",372,233,4,5,1,0,0,0,0
+"Woodbridge, Ward 4, District 10",396,195,15,3,1,0,0,0,0
+"Woodbridge, Ward 4, District 11",294,127,5,4,1,2,0,0,0
+"Woodbridge, Ward 4, District 12",225,104,1,0,2,0,0,0,1
+"Woodbridge, Ward 4, District 13",194,141,5,4,0,0,0,0,0
+"Woodbridge, Ward 4, District 14",239,170,1,5,1,0,0,0,0
+"Woodbridge, Ward 5, District 1",136,277,8,4,1,2,0,0,0
+"Woodbridge, Ward 5, District 2",196,128,7,1,1,0,0,0,0
+"Woodbridge, Ward 5, District 3",154,178,12,3,2,0,0,1,0
+"Woodbridge, Ward 5, District 4",166,211,6,3,0,1,1,0,0
+"Woodbridge, Ward 5, District 5",271,272,11,3,1,0,0,1,0
+"Woodbridge, Ward 5, District 6",273,254,8,14,0,0,0,4,0
+"Woodbridge, Ward 5, District 7",267,296,12,2,0,0,0,2,1
+"Woodbridge, Ward 5, District 8",225,260,17,3,1,1,0,0,0
+"Woodbridge, Ward 5, District 9",357,205,9,8,2,3,0,0,0
+"Woodbridge, Ward 5, District 10",281,293,8,4,1,0,0,0,0
+"Woodbridge, Ward 5, District 11",215,245,9,5,0,1,0,1,0
+"Woodbridge, Ward 5, District 12",250,286,14,10,1,0,1,0,0
+"Woodbridge, Ward 5, District 13",215,227,11,1,0,0,0,0,0
+"Woodbridge, Ward 5, District 14",204,200,7,5,1,0,0,2,1
+"Woodbridge, Ward 5, District 15",175,161,1,1,0,0,0,0,0
+"Woodbridge, Ward 5, District 16",274,279,3,11,0,0,0,1,0
+"Woodbridge, Ward 5, District 17",181,224,7,11,1,0,0,0,0
+"Woodbridge, Ward 5, District 18",116,175,4,1,0,0,0,0,0
+Total,193044,122953,5446,3452,436,368,167,146,90

--- a/2016/Middlesex/General/State Senator 18th Leg. District 1 Yr Unexpired - Middlesex County.csv
+++ b/2016/Middlesex/General/State Senator 18th Leg. District 1 Yr Unexpired - Middlesex County.csv
@@ -1,176 +1,176 @@
 District,"Patrick J. DIEGNAN, Jr.",Roger W. DALEY
-"East Brunswick, District 1",2157,1528
-"East Brunswick, District 2",2386,1582
-"East Brunswick, District 3",2040,1456
-"East Brunswick, District 4",2088,1508
-"East Brunswick, District 5",1958,1359
-"East Brunswick, District 6",1953,1394
-"East Brunswick, District 7",2049,1472
-"East Brunswick, District 8",2045,1439
-"East Brunswick, District 9",1998,1453
-"East Brunswick, District 10",2032,1393
-"East Brunswick, District 11",1926,1383
-"East Brunswick, District 12",2012,1448
-"East Brunswick, District 13",2080,1437
-"East Brunswick, District 14",2154,1574
-"East Brunswick, District 15",1973,1374
-"East Brunswick, District 16",2072,1461
-"East Brunswick, District 17",2055,1438
-"East Brunswick, District 18",1984,1353
-"East Brunswick, District 19",2004,1385
-"East Brunswick, District 20",2134,1533
-"East Brunswick, District 21",2036,1457
-"East Brunswick, District 22",2031,1379
-"East Brunswick, District 23",2098,1501
-"East Brunswick, District 24",2019,1455
-"East Brunswick, District 25",2038,1422
-"East Brunswick, District 26",2096,1525
-"East Brunswick, District 27",2008,1525
-"East Brunswick, District 28",1959,1371
-"East Brunswick, District 29",2071,1437
-"East Brunswick, District 30",2097,1459
-"East Brunswick, District 31",2127,1515
-"East Brunswick, District 32",2012,1388
-"East Brunswick, District 33",2045,1381
-"East Brunswick, District 34",2153,1521
-"East Brunswick, District 35",1950,1394
-"East Brunswick, District 36",2074,1455
-"East Brunswick, District 37",2134,1454
-"East Brunswick, District 38",2036,1419
-"East Brunswick, District 39",2012,1442
-"East Brunswick, District 40",2085,1434
-"Edison, District 1",3117,1413
-"Edison, District 2",3384,1341
-"Edison, District 3",3037,1351
-"Edison, District 4",2954,1310
-"Edison, District 5",3033,1315
-"Edison, District 6",3071,1259
-"Edison, District 7",2922,1262
-"Edison, District 8",2970,1295
-"Edison, District 9",2922,1281
-"Edison, District 10",2984,1332
-"Edison, District 11",3044,1334
-"Edison, District 12",3082,1361
-"Edison, District 13",3020,1270
-"Edison, District 14",3058,1399
-"Edison, District 15",3048,1333
-"Edison, District 16",3057,1359
-"Edison, District 17",3012,1305
-"Edison, District 18",2957,1285
-"Edison, District 19",3006,1311
-"Edison, District 20",2981,1270
-"Edison, District 21",2999,1318
-"Edison, District 22",2962,1291
-"Edison, District 23",3026,1338
-"Edison, District 24",2992,1304
-"Edison, District 25",2978,1275
-"Edison, District 26",2990,1315
-"Edison, District 27",3129,1414
-"Edison, District 28",2952,1214
-"Edison, District 29",3071,1314
-"Edison, District 30",3134,1398
-"Edison, District 31",3040,1322
-"Edison, District 32",2993,1276
-"Edison, District 33",2984,1308
-"Edison, District 34",2934,1300
-"Edison, District 35",3008,1311
-"Edison, District 36",3013,1286
-"Edison, District 37",3028,1345
-"Edison, District 38",3046,1283
-"Edison, District 39",3169,1258
-"Edison, District 40",3011,1306
-"Edison, District 41",2981,1266
-"Edison, District 42",2994,1245
-"Edison, District 43",3264,1293
-"Edison, District 44",3022,1353
-"Edison, District 45",2987,1317
-"Edison, District 46",2978,1296
-"Edison, District 47",2977,1291
-"Edison, District 48",2923,1278
-"Edison, District 49",3035,1316
-"Edison, District 50",3014,1306
-"Edison, District 51",2959,1276
-"Edison, District 52",2983,1304
-"Edison, District 53",3041,1329
-"Edison, District 54",2993,1291
-"Edison, District 55",2939,1272
-"Edison, District 56",2967,1275
-"Edison, District 57",3003,1300
-"Edison, District 58",3111,1242
-"Edison, District 59",2961,1273
-"Edison, District 60",2969,1294
-"Edison, District 61",3087,1343
-"Edison, District 62",2980,1325
-"Edison, District 63",3207,1301
-"Edison, District 64",3128,1353
-"Edison, District 65",3095,1347
-"Edison, District 66",3099,1346
-"Edison, District 67",3053,1383
-"Edison, District 68",3096,1404
-"Edison, District 69",3004,1292
-"Edison, District 70",3204,1347
-"Edison, District 71",3076,1297
-"Edison, District 72",3256,1399
-"Edison, District 73",3088,1367
-"Edison, District 74",3025,1318
-"Edison, District 75",3072,1239
-"Edison, District 76",3146,1334
-"Edison, District 77",3213,1321
-"Edison, District 78",3096,1241
-"Helmetta, District 1",389,497
-"Highland Park, District 1",986,258
-"Highland Park, District 2",939,183
-"Highland Park, District 3",907,187
-"Highland Park, District 4",909,171
-"Highland Park, District 5",962,240
-"Highland Park, District 6",954,176
-"Highland Park, District 7",977,201
-"Highland Park, District 8",938,199
-"Highland Park, District 9",884,218
-"Highland Park, District 10",899,263
-"Highland Park, District 11",910,260
-"Highland Park, District 12",853,185
-"Highland Park, District 13",904,192
-"Metuchen, District 1",958,564
-"Metuchen, District 2",1001,553
-"Metuchen, District 3",939,483
-"Metuchen, District 4",924,474
-"Metuchen, District 5",955,507
-"Metuchen, District 6",897,468
-"Metuchen, District 7",898,480
-"Metuchen, District 8",912,460
-"Metuchen, District 9",860,445
-"Metuchen, District 10",1042,551
-"Metuchen, District 11",1166,578
-"Metuchen, District 12",903,491
-"Metuchen, District 13",845,441
-"South Plainfield, District 1",909,451
-"South Plainfield, District 2",882,532
-"South Plainfield, District 3",885,483
-"South Plainfield, District 4",1072,634
-"South Plainfield, District 5",807,472
-"South Plainfield, District 6",894,515
-"South Plainfield, District 7",971,532
-"South Plainfield, District 8",914,520
-"South Plainfield, District 9",860,521
-"South Plainfield, District 10",1153,550
-"South Plainfield, District 11",828,499
-"South Plainfield, District 12",820,510
-"South Plainfield, District 13",990,535
-"South Plainfield, District 14",910,558
-"South Plainfield, District 15",1035,443
-"South River, District 1",418,343
-"South River, District 2",390,342
-"South River, District 3",376,380
-"South River, District 4",373,369
-"South River, District 5",401,397
-"South River, District 6",419,388
-"South River, District 7",404,359
-"South River, District 8",395,380
-"South River, District 9",417,332
-"South River, District 10",587,468
-"South River, District 11",455,387
-"South River, District 12",443,362
-"South River, District 13",398,364
-"South River, District 14",377,386
-Total,363819,182977
+"East Brunswick, District 1",2337,1643
+"East Brunswick, District 2",562,335
+"East Brunswick, District 3",216,209
+"East Brunswick, District 4",264,261
+"East Brunswick, District 5",134,112
+"East Brunswick, District 6",129,147
+"East Brunswick, District 7",225,225
+"East Brunswick, District 8",221,192
+"East Brunswick, District 9",174,206
+"East Brunswick, District 10",208,146
+"East Brunswick, District 11",102,136
+"East Brunswick, District 12",188,201
+"East Brunswick, District 13",256,190
+"East Brunswick, District 14",330,327
+"East Brunswick, District 15",149,127
+"East Brunswick, District 16",248,214
+"East Brunswick, District 17",231,191
+"East Brunswick, District 18",160,106
+"East Brunswick, District 19",180,138
+"East Brunswick, District 20",310,286
+"East Brunswick, District 21",212,210
+"East Brunswick, District 22",207,132
+"East Brunswick, District 23",274,254
+"East Brunswick, District 24",195,208
+"East Brunswick, District 25",214,175
+"East Brunswick, District 26",272,278
+"East Brunswick, District 27",184,278
+"East Brunswick, District 28",135,124
+"East Brunswick, District 29",247,190
+"East Brunswick, District 30",273,212
+"East Brunswick, District 31",303,268
+"East Brunswick, District 32",188,141
+"East Brunswick, District 33",221,134
+"East Brunswick, District 34",329,274
+"East Brunswick, District 35",126,147
+"East Brunswick, District 36",250,208
+"East Brunswick, District 37",310,207
+"East Brunswick, District 38",212,172
+"East Brunswick, District 39",188,195
+"East Brunswick, District 40",261,187
+"Edison, District 1",3501,1586
+"Edison, District 2",579,159
+"Edison, District 3",232,169
+"Edison, District 4",149,128
+"Edison, District 5",228,133
+"Edison, District 6",266,77
+"Edison, District 7",117,80
+"Edison, District 8",165,113
+"Edison, District 9",117,99
+"Edison, District 10",179,150
+"Edison, District 11",239,152
+"Edison, District 12",277,179
+"Edison, District 13",215,88
+"Edison, District 14",253,217
+"Edison, District 15",243,151
+"Edison, District 16",252,177
+"Edison, District 17",207,123
+"Edison, District 18",152,103
+"Edison, District 19",201,129
+"Edison, District 20",176,88
+"Edison, District 21",194,136
+"Edison, District 22",157,109
+"Edison, District 23",221,156
+"Edison, District 24",187,122
+"Edison, District 25",173,93
+"Edison, District 26",185,133
+"Edison, District 27",324,232
+"Edison, District 28",147,32
+"Edison, District 29",266,132
+"Edison, District 30",329,216
+"Edison, District 31",235,140
+"Edison, District 32",188,94
+"Edison, District 33",179,126
+"Edison, District 34",129,118
+"Edison, District 35",203,129
+"Edison, District 36",208,104
+"Edison, District 37",223,163
+"Edison, District 38",241,101
+"Edison, District 39",364,76
+"Edison, District 40",206,124
+"Edison, District 41",176,84
+"Edison, District 42",189,63
+"Edison, District 43",459,111
+"Edison, District 44",217,171
+"Edison, District 45",182,135
+"Edison, District 46",173,114
+"Edison, District 47",172,109
+"Edison, District 48",118,96
+"Edison, District 49",230,134
+"Edison, District 50",209,124
+"Edison, District 51",154,94
+"Edison, District 52",178,122
+"Edison, District 53",236,147
+"Edison, District 54",188,109
+"Edison, District 55",134,90
+"Edison, District 56",162,93
+"Edison, District 57",198,118
+"Edison, District 58",306,60
+"Edison, District 59",156,91
+"Edison, District 60",164,112
+"Edison, District 61",282,161
+"Edison, District 62",175,143
+"Edison, District 63",402,119
+"Edison, District 64",323,171
+"Edison, District 65",290,165
+"Edison, District 66",294,164
+"Edison, District 67",248,201
+"Edison, District 68",291,222
+"Edison, District 69",199,110
+"Edison, District 70",399,165
+"Edison, District 71",271,115
+"Edison, District 72",451,217
+"Edison, District 73",283,185
+"Edison, District 74",220,136
+"Edison, District 75",267,57
+"Edison, District 76",341,152
+"Edison, District 77",408,139
+"Edison, District 78",291,59
+"Helmetta, District 1",393,506
+"Highland Park, District 1",1057,276
+"Highland Park, District 2",304,61
+"Highland Park, District 3",272,65
+"Highland Park, District 4",274,49
+"Highland Park, District 5",327,118
+"Highland Park, District 6",319,54
+"Highland Park, District 7",342,79
+"Highland Park, District 8",303,77
+"Highland Park, District 9",249,96
+"Highland Park, District 10",264,141
+"Highland Park, District 11",275,138
+"Highland Park, District 12",218,63
+"Highland Park, District 13",269,70
+"Metuchen, District 1",1009,595
+"Metuchen, District 2",339,217
+"Metuchen, District 3",277,147
+"Metuchen, District 4",262,138
+"Metuchen, District 5",293,171
+"Metuchen, District 6",235,132
+"Metuchen, District 7",236,144
+"Metuchen, District 8",250,124
+"Metuchen, District 9",198,109
+"Metuchen, District 10",380,215
+"Metuchen, District 11",504,242
+"Metuchen, District 12",241,155
+"Metuchen, District 13",183,105
+"South Plainfield, District 1",979,485
+"South Plainfield, District 2",308,246
+"South Plainfield, District 3",311,197
+"South Plainfield, District 4",498,348
+"South Plainfield, District 5",233,186
+"South Plainfield, District 6",320,229
+"South Plainfield, District 7",397,246
+"South Plainfield, District 8",340,234
+"South Plainfield, District 9",286,235
+"South Plainfield, District 10",579,264
+"South Plainfield, District 11",254,213
+"South Plainfield, District 12",246,224
+"South Plainfield, District 13",416,249
+"South Plainfield, District 14",336,272
+"South Plainfield, District 15",461,157
+"South River, District 1",451,366
+"South River, District 2",132,118
+"South River, District 3",118,156
+"South River, District 4",115,145
+"South River, District 5",143,173
+"South River, District 6",161,164
+"South River, District 7",146,135
+"South River, District 8",137,156
+"South River, District 9",159,108
+"South River, District 10",329,244
+"South River, District 11",197,163
+"South River, District 12",185,138
+"South River, District 13",140,140
+"South River, District 14",119,162
+Total,50537,31321


### PR DESCRIPTION
This PR resolves an issue of implausible 2016 general returns from Middlesex County. For example, we have ~1.6M reported votes for president, which is twice the county's population. The [latest available](https://mcgisweb.co.middlesex.nj.us/elections/historic/results?e=2016-11-8) returns are quite different and seem reasonable by comparison, so they replace the errant returns.